### PR TITLE
Small improvements in make.sh

### DIFF
--- a/make.sh
+++ b/make.sh
@@ -1,5 +1,7 @@
+#!/usr/bin/env bash
+
 git submodule update --init --recursive
-cd 3rd/luamake
+pushd 3rd/luamake
 ./compile/install.sh
-cd ../..
+popd
 ./3rd/luamake/luamake rebuild


### PR DESCRIPTION
- [Wiki](https://github.com/LuaLS/lua-language-server/wiki/Getting-Started#command-line) states you need to `./make.sh` in order to build project, so `make.sh` needs to be executable.
- Using `pushd`/`popd` instead of `cd`
- Using `bash` in order to not mess with cross-shell compabilities
