### PR TITLE
meta: newproxy can accept a userdata value

### DIFF
--- a/meta/template/basic.lua
+++ b/meta/template/basic.lua
@@ -128,7 +128,7 @@ function loadfile(filename, mode, env) end
 function loadstring(text, chunkname) end
 
 ---@version 5.1
----@param proxy boolean|table
+---@param proxy boolean|table|userdata
 ---@return userdata
 ---@nodiscard
 function newproxy(proxy) end


### PR DESCRIPTION
In the Lua 5.1 source code (Lua 5.1.5 lbaselib.c#432-440):

```c
  else {
    int validproxy = 0;  /* to check if weaktable[metatable(u)] == true */
    if (lua_getmetatable(L, 1)) {
      lua_rawget(L, lua_upvalueindex(1));
      validproxy = lua_toboolean(L, -1);
      lua_pop(L, 1);  /* remove value */
    }
    luaL_argcheck(L, validproxy, 1, "boolean or proxy expected");
    lua_getmetatable(L, 1);  /* metatable is valid; get it */
  }
```
So `newproxy` can accept a userdata created previously with `newproxy(true)`:
![image](https://user-images.githubusercontent.com/38175840/222172125-7044f944-5caa-4722-98e5-d2450e2fc7e8.png)
