### PR TITLE
Improve math.abs annotation

### DIFF
--- a/meta/template/math.lua
+++ b/meta/template/math.lua
@@ -15,8 +15,9 @@
 math = {}
 
 ---#DES 'math.abs'
----@param x number
----@return number
+---@generic Number: number
+---@param x Number
+---@return Number
 ---@nodiscard
 function math.abs(x) end
 


### PR DESCRIPTION
This brings it in line with math.max, and max.min. This change allows the type inference to correctly infer the returned type if math.abs is passed an integer as an argument.