### PR TITLE
Don't override lm.bindir and lm.EXE_DIR in make.lua

### DIFF
--- a/make.lua
+++ b/make.lua
@@ -1,6 +1,5 @@
 local lm = require 'luamake'
 
-lm.bindir = "bin"
 lm.c = lm.compiler == 'msvc' and 'c89' or 'c11'
 lm.cxx = 'c++17'
 
@@ -14,9 +13,6 @@ if lm.sanitize then
         ldflags = "-fsanitize=address"
     }
 end
-
----@diagnostic disable-next-line: codestyle-check
-lm.EXE_DIR = ""
 
 local includeCodeFormat = true
 
@@ -58,9 +54,17 @@ lm:executable "lua-language-server" {
     }
 }
 
+local platform = require 'bee.platform'
+local exe      = platform.OS == 'Windows' and ".exe" or ""
+
+lm:copy "copy_lua-language-server" {
+    input = lm.bindir .. "/lua-language-server" .. exe,
+    output = "bin/lua-language-server" .. exe,
+}
+
 lm:copy "copy_bootstrap" {
     input = "make/bootstrap.lua",
-    output = lm.bindir .. "/main.lua",
+    output = "bin/main.lua",
 }
 
 lm:msvc_copydll 'copy_vcrt' {
@@ -71,6 +75,7 @@ lm:msvc_copydll 'copy_vcrt' {
 lm:phony "all" {
     deps = {
         "lua-language-server",
+        "copy_lua-language-server",
         "copy_bootstrap",
     },
     windows = {
@@ -87,11 +92,8 @@ if lm.notest then
     return
 end
 
-local platform = require 'bee.platform'
-local exe      = platform.OS == 'Windows' and ".exe" or ""
-
 lm:rule "runtest" {
-    lm.bindir .. "/lua-language-server" .. exe, "$in",
+    "bin/lua-language-server" .. exe, "$in",
     description = "Run test: $in.",
     pool = "console",
 }

--- a/make.lua
+++ b/make.lua
@@ -69,7 +69,7 @@ lm:copy "copy_bootstrap" {
 
 lm:msvc_copydll 'copy_vcrt' {
     type = "vcrt",
-    output = lm.bindir,
+    output = "bin",
 }
 
 lm:phony "all" {


### PR DESCRIPTION
Prior to this change, the targets `/main.lua` and `/bootstrap.lua` in `build/build.ninja` were being generated, which in turn caused access violations during the build. I was having problems building on Gentoo because of this (their package manager sandboxes their builds).

 To illustrate, here's a diff of `build/build.ninja` generated before and after this change.
```
--- a/build/build.ninja
+++ b/build/build.ninja
@@ -1,6 +1,6 @@
 ninja_required_version = 1.7
 builddir = build
-bin = bin
+bin = $builddir/bin
 obj = $builddir/obj
 cc = gcc
 luamake = /home/arya/lua-language-server/3rd/luamake/luamake
@@ -109,7 +109,7 @@
   command = $cc $in -o $out -lm -ldl -Wl,-E -lstdc++fs -pthread $
     -Wl,-Bstatic -lstdc++ -Wl,-Bdynamic -static-libgcc -s
   description = Link    Exe $out
-build /bootstrap: link_bootstrap $obj/source_bootstrap/main.obj $
+build $bin/bootstrap: link_bootstrap $obj/source_bootstrap/main.obj $
     $obj/source_bootstrap/progdir.obj $obj/source_bee/lua-seri.obj $
     $obj/source_bee/format.obj $obj/source_bee/os.obj $
     $obj/source_bee/error.obj $obj/source_bee/filewatch_linux.obj $
@@ -128,10 +128,10 @@
   command = cp -fv $in$input $out 1>/dev/null
   description = Copy $in$input $out
   restat = 1
-build /main.lua: copy | /bootstrap
+build $bin/main.lua: copy | $bin/bootstrap
   input = 3rd/bee.lua/bootstrap/main.lua
 rule test
-  command = /bootstrap 3rd/bee.lua/test/test.lua --touch $out
+  command = $bin/bootstrap 3rd/bee.lua/test/test.lua --touch $out
   description = Run test.
   pool = console
 build $obj/test.stamp: test 3rd/bee.lua/test/console.lua $
@@ -143,7 +143,7 @@
     3rd/bee.lua/test/test_serialization.lua $
     3rd/bee.lua/test/test_socket.lua 3rd/bee.lua/test/test_subprocess.lua $
     3rd/bee.lua/test/test_thread.lua 3rd/bee.lua/test/test_time.lua | $
-    /bootstrap copy_script
+    $bin/bootstrap copy_script
 rule cxx_code_format
   command = $cc -MMD -MT $out -MF $out.d -std=c++17 -O2 -Wall $
     -fvisibility=hidden -I3rd/EmmyLuaCodeStyle/include $
@@ -314,6 +314,7 @@
     $obj/code_format/StringUtil.obj $obj/code_format/EditDistance.obj $
     $obj/code_format/SuggestItem.obj $obj/code_format/SymSpell.obj $
     $obj/code_format/Utf8.obj
+build bin/lua-language-server: copy $builddir/bin/lua-language-server
 build bin/main.lua: copy make/bootstrap.lua
 rule runtest
   command = bin/lua-language-server $in
@@ -321,12 +322,14 @@
   pool = console
 build $builddir/_/bee-test: runtest 3rd/bee.lua/test/test.lua | all
 build $builddir/_/unit-test: runtest test.lua | bee-test all
-build bootstrap: phony /bootstrap
-build copy_script: phony /main.lua
+build bootstrap: phony $bin/bootstrap
+build copy_script: phony $bin/main.lua
 build test: phony $obj/test.stamp
 build lua-language-server: phony $bin/lua-language-server
+build copy_lua-language-server: phony bin/lua-language-server
 build copy_bootstrap: phony bin/main.lua
-build all: phony $bin/lua-language-server copy_bootstrap
+build all: phony $bin/lua-language-server copy_lua-language-server $
+    copy_bootstrap
 build bee-test: phony $builddir/_/bee-test
 build unit-test: phony $builddir/_/unit-test
 default unit-test
```

I also had to add the `copy_lua-language-server` rule both to retain the previous behavior of placing the executable in bin/, but also because without it ninja complains that there are two rules for `main.lua`.