### PR TITLE
Make functions in string api accept numbers

### DIFF
--- a/meta/template/string.lua
+++ b/meta/template/string.lua
@@ -5,7 +5,7 @@
 string = {}
 
 ---#DES 'string.byte'
----@param s  string
+---@param s  string|number
 ---@param i? integer
 ---@param j? integer
 ---@return integer ...
@@ -27,7 +27,7 @@ function string.char(byte, ...) end
 function string.dump(f, strip) end
 
 ---#DES 'string.find'
----@param s       string
+---@param s       string|number
 ---@param pattern string
 ---@param init?   integer
 ---@param plain?  boolean
@@ -60,7 +60,7 @@ function string.gmatch(s, pattern, init) end
 ---#end
 
 ---#DES 'string.gsub'
----@param s       string
+---@param s       string|number
 ---@param pattern string
 ---@param repl    string|number|table|function
 ---@param n?      integer
@@ -70,19 +70,19 @@ function string.gmatch(s, pattern, init) end
 function string.gsub(s, pattern, repl, n) end
 
 ---#DES 'string.len'
----@param s string
+---@param s string|number
 ---@return integer
 ---@nodiscard
 function string.len(s) end
 
 ---#DES 'string.lower'
----@param s string
+---@param s string|number
 ---@return string
 ---@nodiscard
 function string.lower(s) end
 
 ---#DES 'string.match'
----@param s       string
+---@param s       string|number
 ---@param pattern string
 ---@param init?   integer
 ---@return any ...
@@ -107,14 +107,14 @@ function string.packsize(fmt) end
 
 ---#if VERSION <= 5.1 and not JIT then
 ---#DES 'string.rep<5.1'
----@param s    string
+---@param s    string|number
 ---@param n    integer
 ---@return string
 ---@nodiscard
 function string.rep(s, n) end
 ---#else
 ---#DES 'string.rep>5.2'
----@param s    string
+---@param s    string|number
 ---@param n    integer
 ---@param sep? string
 ---@return string
@@ -123,13 +123,13 @@ function string.rep(s, n, sep) end
 ---#end
 
 ---#DES 'string.reverse'
----@param s string
+---@param s string|number
 ---@return string
 ---@nodiscard
 function string.reverse(s) end
 
 ---#DES 'string.sub'
----@param s  string
+---@param s  string|number
 ---@param i  integer
 ---@param j? integer
 ---@return string
@@ -147,7 +147,7 @@ function string.sub(s, i, j) end
 function string.unpack(fmt, s, pos) end
 
 ---#DES 'string.upper'
----@param s string
+---@param s string|number
 ---@return string
 ---@nodiscard
 function string.upper(s) end

--- a/meta/template/string.lua
+++ b/meta/template/string.lua
@@ -38,7 +38,7 @@ function string.dump(f, strip) end
 function string.find(s, pattern, init, plain) end
 
 ---#DES 'string.format'
----@param s any
+---@param s string|number
 ---@param ... any
 ---@return string
 ---@nodiscard

--- a/meta/template/string.lua
+++ b/meta/template/string.lua
@@ -46,14 +46,14 @@ function string.format(s, ...) end
 
 ---#DES 'string.gmatch'
 ---#if VERSION <= 5.3 then
----@param s       string
----@param pattern string
+---@param s       string|number
+---@param pattern string|number
 ---@return fun():string, ...
 ---@nodiscard
 function string.gmatch(s, pattern) end
 ---#else
----@param s       string
----@param pattern string
+---@param s       string|number
+---@param pattern string|number
 ---@param init?   integer
 ---@return fun():string, ...
 function string.gmatch(s, pattern, init) end

--- a/meta/template/string.lua
+++ b/meta/template/string.lua
@@ -28,7 +28,7 @@ function string.dump(f, strip) end
 
 ---#DES 'string.find'
 ---@param s       string|number
----@param pattern string
+---@param pattern string|number
 ---@param init?   integer
 ---@param plain?  boolean
 ---@return integer start
@@ -61,7 +61,7 @@ function string.gmatch(s, pattern, init) end
 
 ---#DES 'string.gsub'
 ---@param s       string|number
----@param pattern string
+---@param pattern string|number
 ---@param repl    string|number|table|function
 ---@param n?      integer
 ---@return string
@@ -83,7 +83,7 @@ function string.lower(s) end
 
 ---#DES 'string.match'
 ---@param s       string|number
----@param pattern string
+---@param pattern string|number
 ---@param init?   integer
 ---@return any ...
 ---@nodiscard
@@ -116,7 +116,7 @@ function string.rep(s, n) end
 ---#DES 'string.rep>5.2'
 ---@param s    string|number
 ---@param n    integer
----@param sep? string
+---@param sep? string|number
 ---@return string
 ---@nodiscard
 function string.rep(s, n, sep) end

--- a/test/hover/init.lua
+++ b/test/hover/init.lua
@@ -238,14 +238,14 @@ TEST [[
 string.<?sub?>()
 ]]
 [[
-function string.sub(s: string, i: integer, j?: integer)
+function string.sub(s: string|number, i: integer, j?: integer)
   -> string
 ]]
 
 TEST[[
 ('xx'):<?sub?>()
 ]]
-[[function string.sub(s: string, i: integer, j?: integer)
+[[function string.sub(s: string|number, i: integer, j?: integer)
   -> string]]
 
 TEST [[
@@ -272,7 +272,7 @@ TEST [[
 string.<?lower?>()
 ]]
 [[
-function string.lower(s: string)
+function string.lower(s: string|number)
   -> string
 ]]
 


### PR DESCRIPTION
All of these functions effectively call `tostring()`, when the passed parameter is a number. I think there is no need to raise warnings if users pass numbers instead of strings to these functions.

You can test this easily online: https://www.lua.org/cgi-bin/demo.