### PR TITLE
Add diagnostic to enforce lowercase local element names

### DIFF
--- a/doc/en-us/config.md
+++ b/doc/en-us/config.md
@@ -329,6 +329,7 @@ Array<string>
 * ``"unused-label"``
 * ``"unused-local"``
 * ``"unused-vararg"``
+* ``"uppercase-local"``
 
 ## default
 
@@ -470,6 +471,7 @@ object<string, string>
     "strict": "Fallback",
     /*
     * global-element
+    * uppercase-local
     */
     "conventions": "None",
     /*
@@ -593,6 +595,7 @@ object<string, string>
     "strict": "Fallback",
     /*
     * global-element
+    * uppercase-local
     */
     "conventions": "Fallback",
     /*
@@ -926,7 +929,11 @@ object<string, string>
     /*
     Enable unused vararg diagnostics.
     */
-    "unused-vararg": "Opened"
+    "unused-vararg": "Opened",
+    /*
+    Enable diagnostics to warn about local element names starting with an uppercase letter.
+    */
+    "uppercase-local": "None"
 }
 ```
 
@@ -1178,7 +1185,11 @@ object<string, string>
     /*
     Enable unused vararg diagnostics.
     */
-    "unused-vararg": "Hint"
+    "unused-vararg": "Hint",
+    /*
+    Enable diagnostics to warn about local element names starting with an uppercase letter.
+    */
+    "uppercase-local": "Warning"
 }
 ```
 

--- a/doc/pt-br/config.md
+++ b/doc/pt-br/config.md
@@ -329,6 +329,7 @@ Array<string>
 * ``"unused-label"``
 * ``"unused-local"``
 * ``"unused-vararg"``
+* ``"uppercase-local"``
 
 ## default
 
@@ -470,6 +471,7 @@ object<string, string>
     "strict": "Fallback",
     /*
     * global-element
+    * uppercase-local
     */
     "conventionss": "None",
     /*
@@ -593,6 +595,7 @@ object<string, string>
     "strict": "Fallback",
     /*
     * global-element
+    * uppercase-local
     */
     "conventionss": "Fallback",
     /*
@@ -926,7 +929,11 @@ object<string, string>
     /*
     未使用的不定参数
     */
-    "unused-vararg": "Opened"
+    "unused-vararg": "Opened",
+    /*
+    Enable diagnostics to warn about local element names starting with an uppercase letter.
+    */
+    "uppercase-local": "None"
 }
 ```
 
@@ -1178,7 +1185,11 @@ object<string, string>
     /*
     未使用的不定参数
     */
-    "unused-vararg": "Hint"
+    "unused-vararg": "Hint",
+    /*
+    Enable diagnostics to warn about local element names starting with an uppercase letter.
+    */
+    "uppercase-local": "Warning"
 }
 ```
 

--- a/doc/zh-cn/config.md
+++ b/doc/zh-cn/config.md
@@ -329,6 +329,7 @@ Array<string>
 * ``"unused-label"``
 * ``"unused-local"``
 * ``"unused-vararg"``
+* ``"uppercase-local"``
 
 ## default
 
@@ -470,6 +471,7 @@ object<string, string>
     "strict": "Fallback",
     /*
     * global-element
+    * uppercase-local
     */
     "conventions": "None",
     /*
@@ -593,6 +595,7 @@ object<string, string>
     "strict": "Fallback",
     /*
     * global-element
+    * uppercase-local
     */
     "conventions": "Fallback",
     /*
@@ -926,7 +929,11 @@ object<string, string>
     /*
     未使用的不定参数
     */
-    "unused-vararg": "Opened"
+    "unused-vararg": "Opened",
+    /*
+    Enable diagnostics to warn about local element names starting with an uppercase letter.
+    */
+    "uppercase-local": "None"
 }
 ```
 
@@ -1177,7 +1184,11 @@ object<string, string>
     /*
     未使用的不定参数
     */
-    "unused-vararg": "Hint"
+    "unused-vararg": "Hint",
+    /*
+    Enable diagnostics to warn about local element names starting with an uppercase letter.
+    */
+    "uppercase-local": "Warning"
 }
 ```
 

--- a/doc/zh-tw/config.md
+++ b/doc/zh-tw/config.md
@@ -329,6 +329,7 @@ Array<string>
 * ``"unused-label"``
 * ``"unused-local"``
 * ``"unused-vararg"``
+* ``"uppercase-local"``
 
 ## default
 
@@ -470,6 +471,7 @@ object<string, string>
     "strict": "Fallback",
     /*
     * global-element
+    * uppercase-local
     */
     "convention": "None",
     /*
@@ -593,6 +595,7 @@ object<string, string>
     "strict": "Fallback",
     /*
     * global-element
+    * uppercase-local
     */
     "convention": "Fallback",
     /*
@@ -926,7 +929,11 @@ object<string, string>
     /*
     未使用的不定引數
     */
-    "unused-vararg": "Opened"
+    "unused-vararg": "Opened",
+    /*
+    Enable diagnostics to warn about local element names starting with an uppercase letter.
+    */
+    "uppercase-local": "None"
 }
 ```
 
@@ -1177,7 +1184,11 @@ object<string, string>
     /*
     未使用的不定引數
     */
-    "unused-vararg": "Hint"
+    "unused-vararg": "Hint",
+    /*
+    Enable diagnostics to warn about local element names starting with an uppercase letter.
+    */
+    "uppercase-local": "Warning"
 }
 ```
 

--- a/locale/en-us/script.lua
+++ b/locale/en-us/script.lua
@@ -150,8 +150,11 @@ DIAG_INVISIBLE_PROTECTED              =
 'Field `{field}` is protected, it can only be accessed in class `{class}` and its subclasses.'
 DIAG_INVISIBLE_PACKAGE                =
 'Field `{field}` can only be accessed in same file `{uri}`.'
-DIAG_GLOBAL_ELEMENT                  =
+DIAG_GLOBAL_ELEMENT                   =
 'Element is global.'
+DIAG_UPPERCASE_LOCAL                  =
+'Local element `{}` must start with lowercase letter'
+
 
 MWS_NOT_SUPPORT         =
 '{} does not support multi workspace for now, I may need to restart to support the new workspace ...'

--- a/locale/en-us/setting.lua
+++ b/locale/en-us/setting.lua
@@ -415,8 +415,10 @@ config.diagnostics['unknown-operator']      =
 'Enable diagnostics for unknown operators.'
 config.diagnostics['unreachable-code']      =
 'Enable diagnostics for unreachable code.'
-config.diagnostics['global-element']       =
-'Enable diagnostics to warn about global elements.'
+config.diagnostics['global-element']        =
+'Enable diagnostics to warn about global variables.'
+config.diagnostics['uppercase-local']       =
+'Enable diagnostics to warn about local element names starting with an uppercase letter.'
 config.typeFormat.config                    =
 'Configures the formatting behavior while typing Lua code.'
 config.typeFormat.config.auto_complete_end  =

--- a/locale/pt-br/script.lua
+++ b/locale/pt-br/script.lua
@@ -150,8 +150,10 @@ DIAG_INVISIBLE_PROTECTED              = -- TODO: need translate!
 'Field `{field}` is protected, it can only be accessed in class `{class}` and its subclasses.'
 DIAG_INVISIBLE_PACKAGE                = -- TODO: need translate!
 'Field `{field}` can only be accessed in same file `{uri}`.'
-DIAG_GLOBAL_ELEMENT                  = -- TODO: need translate!
+DIAG_GLOBAL_ELEMENT                   = -- TODO: need translate!
 'Element is global.'
+DIAG_UPPERCASE_LOCAL                  = -- TODO: need translate!
+'Local element `{}` must start with lowercase letter'
 
 MWS_NOT_SUPPORT         =
 '{} não é suportado múltiplos espaços de trabalho por enquanto, posso precisar reiniciar para estabelecer um novo espaço de trabalho ...'

--- a/locale/pt-br/setting.lua
+++ b/locale/pt-br/setting.lua
@@ -415,8 +415,10 @@ config.diagnostics['unknown-operator']      = -- TODO: need translate!
 'Enable diagnostics for unknown operators.'
 config.diagnostics['unreachable-code']      = -- TODO: need translate!
 'Enable diagnostics for unreachable code.'
-config.diagnostics['global-element']       = -- TODO: need translate!
-'Enable diagnostics to warn about global elements.'
+config.diagnostics['global-element']        = -- TODO: need translate!
+'Enable diagnostics to warn about global variables.'
+config.diagnostics['uppercase-local']       = -- TODO: need translate!
+'Enable diagnostics to warn about local element names starting with an uppercase letter.'
 config.typeFormat.config                    = -- TODO: need translate!
 'Configures the formatting behavior while typing Lua code.'
 config.typeFormat.config.auto_complete_end  = -- TODO: need translate!

--- a/locale/zh-cn/script.lua
+++ b/locale/zh-cn/script.lua
@@ -150,8 +150,10 @@ DIAG_INVISIBLE_PROTECTED              =
 '字段 `{field}` 受到保护，只能在 `{class}` 类极其子类中才能访问。'
 DIAG_INVISIBLE_PACKAGE                =
 '字段 `{field}` 只能在相同的文件 `{uri}` 中才能访问。'
-DIAG_GLOBAL_ELEMENT                  = -- TODO: need translate!
+DIAG_GLOBAL_ELEMENT                   = -- TODO: need translate!
 'Element is global.'
+DIAG_UPPERCASE_LOCAL                  = -- TODO: need translate!
+'Local element `{}` must start with lowercase letter'
 
 MWS_NOT_SUPPORT         =
 '{} 目前还不支持多工作目录，我可能需要重启才能支持新的工作目录...'

--- a/locale/zh-cn/setting.lua
+++ b/locale/zh-cn/setting.lua
@@ -414,8 +414,10 @@ config.diagnostics['unknown-operator']      = -- TODO: need translate!
 'Enable diagnostics for unknown operators.'
 config.diagnostics['unreachable-code']      = -- TODO: need translate!
 'Enable diagnostics for unreachable code.'
-config.diagnostics['global-element']       = -- TODO: need translate!
-'Enable diagnostics to warn about global elements.'
+config.diagnostics['global-element']        = -- TODO: need translate!
+'Enable diagnostics to warn about global variables.'
+config.diagnostics['uppercase-local']       = -- TODO: need translate!
+'Enable diagnostics to warn about local element names starting with an uppercase letter.'
 config.typeFormat.config                    = -- TODO: need translate!
 'Configures the formatting behavior while typing Lua code.'
 config.typeFormat.config.auto_complete_end  = -- TODO: need translate!

--- a/locale/zh-tw/script.lua
+++ b/locale/zh-tw/script.lua
@@ -150,8 +150,10 @@ DIAG_INVISIBLE_PROTECTED              = -- TODO: need translate!
 'Field `{field}` is protected, it can only be accessed in class `{class}` and its subclasses.'
 DIAG_INVISIBLE_PACKAGE                = -- TODO: need translate!
 'Field `{field}` can only be accessed in same file `{uri}`.'
-DIAG_GLOBAL_ELEMENT                  = -- TODO: need translate!
+DIAG_GLOBAL_ELEMENT                   = -- TODO: need translate!
 'Element is global.'
+DIAG_UPPERCASE_LOCAL                  = -- TODO: need translate!
+'Local element `{}` must start with lowercase letter'
 
 MWS_NOT_SUPPORT         =
 '{} 目前還不支援多工作目錄，我可能需要重新啟動才能支援新的工作目錄...'

--- a/locale/zh-tw/setting.lua
+++ b/locale/zh-tw/setting.lua
@@ -414,8 +414,10 @@ config.diagnostics['unknown-operator']      = -- TODO: need translate!
 'Enable diagnostics for unknown operators.'
 config.diagnostics['unreachable-code']      = -- TODO: need translate!
 'Enable diagnostics for unreachable code.'
-config.diagnostics['global-element']       = -- TODO: need translate!
-'Enable diagnostics to warn about global elements.'
+config.diagnostics['global-element']        = -- TODO: need translate!
+'Enable diagnostics to warn about global variables.'
+config.diagnostics['uppercase-local']       = -- TODO: need translate!
+'Enable diagnostics to warn about local element names starting with an uppercase letter.'
 config.typeFormat.config                    = -- TODO: need translate!
 'Configures the formatting behavior while typing Lua code.'
 config.typeFormat.config.auto_complete_end  = -- TODO: need translate!

--- a/script/core/diagnostics/uppercase-local.lua
+++ b/script/core/diagnostics/uppercase-local.lua
@@ -1,0 +1,47 @@
+local files     = require 'files'
+local guide     = require 'parser.guide'
+local lang      = require 'language'
+
+local function isDocClass(source)
+    if not source.bindDocs then
+        return false
+    end
+    for _, doc in ipairs(source.bindDocs) do
+        if doc.type == 'doc.class' then
+            return true
+        end
+    end
+    return false
+end
+
+-- If local elements must be named lowercase by coding convention, this diagnostic helps with reminding about that
+return function (uri, callback)
+    local ast = files.getState(uri)
+    if not ast then
+        return
+    end
+
+    guide.eachSourceType(ast.ast, 'local', function (source)
+        local name = guide.getKeyName(source)
+        if not name then
+            return
+        end
+        local first = name:match '%w' -- alphanumeric character
+        if not first then
+            return
+        end
+        if not first:match '%u' then -- uppercase
+            return
+        end
+        -- If the assignment is marked as doc.class, then it is considered allowed 
+        if isDocClass(source) then
+            return
+        end
+        
+        callback {
+            start   = source.start,
+            finish  = source.finish,
+            message = lang.script('DIAG_UPPERCASE_LOCAL', name),
+        }
+    end)
+end

--- a/script/proto/diagnostic.lua
+++ b/script/proto/diagnostic.lua
@@ -173,6 +173,7 @@ m.register {
 
 m.register {
     'global-element',
+    'uppercase-local',
 } {
     group   = 'conventions',
     severity = 'Warning',

--- a/test/diagnostics/init.lua
+++ b/test/diagnostics/init.lua
@@ -87,3 +87,4 @@ end
 require 'diagnostics.common'
 require 'diagnostics.type-check'
 require 'diagnostics.global-element'
+require 'diagnostics.uppercase-local'

--- a/test/diagnostics/uppercase-local.lua
+++ b/test/diagnostics/uppercase-local.lua
@@ -1,0 +1,66 @@
+local config = require 'config'
+local util   = require 'utility'
+
+-- disable all default groups to make isolated tests
+config.set(nil, 'Lua.diagnostics.groupFileStatus', 
+{
+    ['ambiguity']     = 'None',
+    ['await']         = 'None',
+    ['codestyle']     = 'None',
+    ['conventions']   = 'None',
+    ['duplicate']     = 'None',
+    ['global']        = 'None',
+    ['luadoc']        = 'None',
+    ['redefined']     = 'None',
+    ['strict']        = 'None',
+    ['strong']        = 'None',
+    ['type-check']    = 'None',
+    ['unbalanced']    = 'None',
+    ['unused']        = 'None'
+})
+
+-- enable single diagnostic that is to be tested
+config.set(nil, 'Lua.diagnostics.neededFileStatus',
+{
+    ['uppercase-local'] = 'Any!' -- override groupFileStatus
+})
+
+-- check that global elements are not warned about
+TEST [[
+Var1 = "global"
+VAR2 = "global"
+
+local x = true
+local <!Y!> = false
+local <!Var!> = false
+]]
+
+TEST [[
+local function test1()
+    print()
+end
+
+local function <!Test2!>()
+    print()
+end
+]]
+
+TEST [[
+local function closure1()
+    local elem1 = 1
+    local <!Elem2!> = 2
+end
+
+local function <!Closure2!>()
+    local elem1 = 1
+    local <!Elem2!> = 2
+end
+]]
+
+-- reset configurations
+config.set(nil, 'Lua.diagnostics.groupFileStatus', 
+{})
+config.set(nil, 'Lua.diagnostics.neededFileStatus',
+{})
+config.set(nil, 'Lua.diagnostics.globals',
+{})


### PR DESCRIPTION
This PR adds a diagnostic that is a counterpart to the diagnostic `lowercase-global`. It allows enforcing local element names to always start with lowercase letters.

- diagnostic `uppercase-local` in group `conventions`; disabled by default (Severity `Warning`, Filestatus `None`)
- isolated unit tests for diagnostic