### PR TITLE
fix: do not overwrite config files when building

### DIFF
--- a/make.sh
+++ b/make.sh
@@ -2,6 +2,6 @@
 
 git submodule update --init --recursive
 pushd 3rd/luamake
-./compile/install.sh
+./compile/build.sh
 popd
 ./3rd/luamake/luamake rebuild


### PR DESCRIPTION
I recently introduced this project into my dotfiles, but then I noticed that running `make.sh` ends up adding an alias to my `.zshrc`. The culprit was [this line from `luamake`](https://github.com/actboy168/luamake/blob/295950da763e2bf75956c56fdc7c8c2877aac4ad/compile/install.sh#L35).
The fix to the issue is to not run `install.sh`, but just run `build.sh`