### PR TITLE
add: description for `@source`

### DIFF
--- a/locale/en-us/script.lua
+++ b/locale/en-us/script.lua
@@ -1199,6 +1199,33 @@ local function setColor(color) end
 setColor(colors.green)
 ```
 ]=]
+LUADOC_DESC_SOURCE =
+[=[
+Provide a reference to some source code which lives in another file. When
+searching for the defintion of an item, its `@source` will be used.
+
+## Syntax
+`@source <path>`
+
+## Usage
+```
+---You can use absolute paths
+---@source C:/Users/me/Documents/program/myFile.c
+local a
+
+---Or URIs
+---@source file:///C:/Users/me/Documents/program/myFile.c:10
+local b
+
+---Or relative paths
+---@source local/file.c
+local c
+
+---You can also include line and char numbers
+---@source local/file.c:10:8
+local d
+```
+]=]
 LUADOC_DESC_PACKAGE =
 [=[
 Mark a function as private to the file it is defined in. A packaged function

--- a/locale/pt-br/script.lua
+++ b/locale/pt-br/script.lua
@@ -1199,6 +1199,33 @@ local function setColor(color) end
 setColor(colors.green)
 ```
 ]=]
+LUADOC_DESC_SOURCE = -- TODO: need translate!
+[=[
+Provide a reference to some source code which lives in another file. When
+searching for the defintion of an item, its `@source` will be used.
+
+## Syntax
+`@source <path>`
+
+## Usage
+```
+---You can use absolute paths
+---@source C:/Users/me/Documents/program/myFile.c
+local a
+
+---Or URIs
+---@source file:///C:/Users/me/Documents/program/myFile.c:10
+local b
+
+---Or relative paths
+---@source local/file.c
+local c
+
+---You can also include line and char numbers
+---@source local/file.c:10:8
+local d
+```
+]=]
 LUADOC_DESC_PACKAGE = -- TODO: need translate!
 [=[
 Mark a function as private to the file it is defined in. A packaged function

--- a/locale/zh-cn/script.lua
+++ b/locale/zh-cn/script.lua
@@ -1199,6 +1199,33 @@ local function setColor(color) end
 setColor(colors.green)
 ```
 ]=]
+LUADOC_DESC_SOURCE = -- TODO: need translate!
+[=[
+Provide a reference to some source code which lives in another file. When
+searching for the defintion of an item, its `@source` will be used.
+
+## Syntax
+`@source <path>`
+
+## Usage
+```
+---You can use absolute paths
+---@source C:/Users/me/Documents/program/myFile.c
+local a
+
+---Or URIs
+---@source file:///C:/Users/me/Documents/program/myFile.c:10
+local b
+
+---Or relative paths
+---@source local/file.c
+local c
+
+---You can also include line and char numbers
+---@source local/file.c:10:8
+local d
+```
+]=]
 LUADOC_DESC_PACKAGE = -- TODO: need translate!
 [=[
 Mark a function as private to the file it is defined in. A packaged function

--- a/locale/zh-tw/script.lua
+++ b/locale/zh-tw/script.lua
@@ -1193,6 +1193,33 @@ local function setColor(color) end
 setColor(colors.green)
 ```
 ]=]
+LUADOC_DESC_SOURCE = -- TODO: need translate!
+[=[
+Provide a reference to some source code which lives in another file. When
+searching for the defintion of an item, its `@source` will be used.
+
+## Syntax
+`@source <path>`
+
+## Usage
+```
+---You can use absolute paths
+---@source C:/Users/me/Documents/program/myFile.c
+local a
+
+---Or URIs
+---@source file:///C:/Users/me/Documents/program/myFile.c:10
+local b
+
+---Or relative paths
+---@source local/file.c
+local c
+
+---You can also include line and char numbers
+---@source local/file.c:10:8
+local d
+```
+]=]
 LUADOC_DESC_PACKAGE = -- TODO: need translate!
 [=[
 Mark a function as private to the file it is defined in. A packaged function


### PR DESCRIPTION
Adds a description for [`@source`](https://github.com/LuaLS/lua-language-server/wiki/Annotations#source), in English, to all locales.