### PR TITLE
Update `string.dump` so it doesn't have strip argument in Lua 5.1 and 5.2

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # changelog
 
+## 3.6.26
+* `FIX` [#2224]
+
+[#2224]: https://github.com/LuaLS/lua-language-server/issues/2224
+
 ## 3.6.25
 `2023-7-26`
 * `FIX` [#2214]

--- a/meta/template/string.lua
+++ b/meta/template/string.lua
@@ -20,11 +20,18 @@ function string.byte(s, i, j) end
 function string.char(byte, ...) end
 
 ---#DES 'string.dump'
+---#if VERSION >= 5.3 or JIT then
 ---@param f      async fun(...):...
 ---@param strip? boolean
 ---@return string
 ---@nodiscard
 function string.dump(f, strip) end
+---#else
+---@param f      async fun(...):...
+---@return string
+---@nodiscard
+function string.dump(f) end
+---#end
 
 ---#DES 'string.find'
 ---@param s       string|number
@@ -93,6 +100,7 @@ function string.match(s, pattern, init) end
 ---#DES 'string.pack'
 ---@param fmt string
 ---@param v1  string|number
+---@param v2  string|number
 ---@param ... string|number
 ---@return string binary
 ---@nodiscard


### PR DESCRIPTION
Fixes #2224. I hope I figured out the syntax used in these templates correctly.

Note:
 - LuaJIT also [includes](https://luajit.org/extensions.html) the strip argument for `string.dump`.