### PR TITLE
Ignore `cast-local-type` diagnostic for `_` local

### DIFF
--- a/script/core/diagnostics/cast-local-type.lua
+++ b/script/core/diagnostics/cast-local-type.lua
@@ -16,6 +16,9 @@ return function (uri, callback)
         if not loc.ref then
             return
         end
+        if loc[1] == '_' then
+            return
+        end
         await.delay()
         local locNode = vm.compileNode(loc)
         if not locNode.hasDefined then


### PR DESCRIPTION
The `unused-local` diagnostic already hard-codes to exclude `_`.
`cast-local-type` should also ignore `_` variables, to avoid warnings
in, for example, nested loops like:

```lua
for _, list in ipairs(lists) do
  for _, item in ipairs(list) do
    _, result = pcall(...)
  end
end
```
