### PR TITLE
set min version for some math.* functions

### DIFF
--- a/locale/en-us/meta.lua
+++ b/locale/en-us/meta.lua
@@ -519,11 +519,11 @@ math.log10                  =
 'Returns the base-10 logarithm of x.'
 math.max                    =
 'Returns the argument with the maximum value, according to the Lua operator `<`.'
-math.maxinteger             =
+math.maxinteger['>5.3']     =
 'An integer with the maximum value for an integer.'
 math.min                    =
 'Returns the argument with the minimum value, according to the Lua operator `<`.'
-math.mininteger             =
+math.mininteger['>5.3']     =
 'An integer with the minimum value for an integer.'
 math.modf                   =
 'Returns the integral part of `x` and the fractional part of `x`.'
@@ -557,11 +557,11 @@ math.tan                    =
 'Returns the tangent of `x` (assumed to be in radians).'
 math.tanh                   =
 'Returns the hyperbolic tangent of `x` (assumed to be in radians).'
-math.tointeger              =
+math.tointeger['>5.3']      =
 'If the value `x` is convertible to an integer, returns that integer.'
-math.type                   =
+math.type['>5.3']           =
 'Returns `"integer"` if `x` is an integer, `"float"` if it is a float, or `nil` if `x` is not a number.'
-math.ult                    =
+math.ult['>5.3']            =
 'Returns `true` if and only if `m` is below `n` when they are compared as unsigned integers.'
 
 os                          =

--- a/locale/pt-br/meta.lua
+++ b/locale/pt-br/meta.lua
@@ -519,11 +519,11 @@ math.log10                  =
 'Retorna o logaritmo `x` na base 10.'
 math.max                    =
 'Retorna o argumento com o valor máximo de acordo com o operador `<`.'
-math.maxinteger             =
+math.maxinteger['>5.3']     =
 'Retorna o valor máximo para um inteiro.'
 math.min                    =
 'Retorna o argumento com o valor mínimo de acordo com o operador `<`.'
-math.mininteger             =
+math.mixinteger['>5.3']     =
 'Retorna o valor mínimo para um inteiro.'
 math.modf                   =
 'Retorna a parte inteira e a parte fracionária de `x`.'
@@ -557,11 +557,11 @@ math.tan                    =
 'Retorna a tangente de `x` (requer valor em radianos).'
 math.tanh                   =
 'Retorna a tangente hiperbólica de `x` (requer valor em radianos).'
-math.tointeger              =
+math.tointeger['>5.3']      =
 'Se o valor `x` pode ser convertido para um inteiro, retorna esse inteiro.'
-math.type                   =
+math.type['>5.3']           =
 'Retorna `"integer"` se `x` é um inteiro, `"float"` se for um valor real (i.e., ponto flutuante), ou `nil` se `x` não é um número.'
-math.ult                    =
+math.ult['>5.3']            =
 'Retorna `true` se e somente se `m` é menor `n` quando eles são comparados como inteiros sem sinal.'
 
 os                          =

--- a/locale/zh-cn/meta.lua
+++ b/locale/zh-cn/meta.lua
@@ -497,11 +497,11 @@ math.log10                  =
 '返回 `x` 的以10为底的对数。'
 math.max                    =
 '返回参数中最大的值， 大小由 Lua 操作 `<` 决定。'
-math.maxinteger             =
+math.maxinteger['>5.3']     =
 '最大值的整数。'
 math.min                    =
 '返回参数中最小的值， 大小由 Lua 操作 `<` 决定。'
-math.mininteger             =
+math.mininteger['>5.3']     =
 '最小值的整数。'
 math.modf                   =
 '返回 `x` 的整数部分和小数部分。'
@@ -535,11 +535,11 @@ math.tan                    =
 '返回 `x` 的正切值（假定参数是弧度）。'
 math.tanh                   =
 '返回 `x` 的双曲正切值（假定参数是弧度）。'
-math.tointeger              =
+math.tointeger['>5.3']      =
 '如果 `x` 可以转换为一个整数， 返回该整数。'
-math.type                   =
+math.type['>5.3']           =
 '如果 `x` 是整数，返回 `"integer"`， 如果它是浮点数，返回 `"float"`， 如果 `x` 不是数字，返回 `nil`。'
-math.ult                    =
+math.ult['>5.3']            =
 '如果整数 `m` 和 `n` 以无符号整数形式比较， `m` 在 `n` 之下，返回布尔真否则返回假。'
 
 os                          =

--- a/locale/zh-tw/meta.lua
+++ b/locale/zh-tw/meta.lua
@@ -498,11 +498,11 @@ math.log10                  =
 '回傳 `x` 的以10為底的對數。'
 math.max                    =
 '回傳引數中最大的值，大小由 Lua 運算子 `<` 決定。'
-math.maxinteger             =
+math.maxinteger['>5.3']     =
 '最大值的整數。'
 math.min                    =
 '回傳引數中最小的值，大小由 Lua 運算子 `<` 決定。'
-math.mininteger             =
+math.mininteger['>5.3']     =
 '最小值的整數。'
 math.modf                   =
 '回傳 `x` 的整數部分和小數部分。'
@@ -536,11 +536,11 @@ math.tan                    =
 '回傳 `x` 的正切值（假定引數是弧度）。'
 math.tanh                   =
 '回傳 `x` 的雙曲正切值（假定引數是弧度）。'
-math.tointeger              =
+math.tointeger['>5.3']      =
 '如果 `x` 可以轉換為一個整數，回傳該整數。'
-math.type                   =
+math.type['>5.3']           =
 '如果 `x` 是整數，回傳 `"integer"` ，如果它是浮點數，回傳 `"float"` ，如果 `x` 不是數字，回傳 `nil` 。'
-math.ult                    =
+math.ult['>5.3']            =
 '整數 `m` 和 `n` 以無符號整數形式比較，如果 `m` 在 `n` 之下則回傳布林真，否則回傳假。'
 
 os                          =


### PR DESCRIPTION
This updates `meta.lua` to fix the minimum versions on several `math` attributes that did not exist prior to Lua 5.3.

I followed samples from the surrounding code, but I'm not sure if I formatted these correctly.