### PR TITLE
Add setting to override nonstandardSymbol Type

### DIFF
--- a/doc/en-us/config.md
+++ b/doc/en-us/config.md
@@ -1815,6 +1815,20 @@ Array<string>
 []
 ```
 
+# runtime.nonstandardSymbolTypes
+
+Set the type for non standardSymbols to something other than string.
+
+## type
+```ts
+Object<string, string>
+```
+
+## default
+```jsonc
+{}
+```
+
 # runtime.path
 
 When using `require`, how to find the file based on the input name.

--- a/doc/pt-br/config.md
+++ b/doc/pt-br/config.md
@@ -1815,6 +1815,20 @@ Array<string>
 []
 ```
 
+# runtime.nonstandardSymbolTypes
+
+Set the type for non standardSymbols to something other than string.
+
+## type
+```ts
+Object<string, string>
+```
+
+## default
+```jsonc
+{}
+```
+
 # runtime.path
 
 When using `require`, how to find the file based on the input name.

--- a/doc/zh-cn/config.md
+++ b/doc/zh-cn/config.md
@@ -1814,6 +1814,20 @@ Array<string>
 []
 ```
 
+# runtime.nonstandardSymbolTypes
+
+Set the type for non standardSymbols to something other than string.
+
+## type
+```ts
+Object<string, string>
+```
+
+## default
+```jsonc
+{}
+```
+
 # runtime.path
 
 当使用 `require` 时，如何根据输入的名字来查找文件。

--- a/doc/zh-tw/config.md
+++ b/doc/zh-tw/config.md
@@ -1814,6 +1814,20 @@ Array<string>
 []
 ```
 
+# runtime.nonstandardSymbolTypes
+
+Set the type for non standardSymbols to something other than string.
+
+## type
+```ts
+Object<string, string>
+```
+
+## default
+```jsonc
+{}
+```
+
 # runtime.path
 
 當使用 `require` 時，如何根據輸入的名字來尋找檔案。

--- a/locale/en-us/setting.lua
+++ b/locale/en-us/setting.lua
@@ -26,6 +26,8 @@ config.runtime.unicodeName        =
 "Allows Unicode characters in name."
 config.runtime.nonstandardSymbol  =
 "Supports non-standard symbols. Make sure that your runtime environment supports these symbols."
+config.runtime.nonstandardSymbolTypes =
+"Override the type for non-standard symbols."
 config.runtime.plugin             =
 "Plugin path. Please read [wiki](https://luals.github.io/wiki/plugins) to learn more."
 config.runtime.pluginArgs         =

--- a/locale/pt-br/setting.lua
+++ b/locale/pt-br/setting.lua
@@ -26,6 +26,8 @@ config.runtime.unicodeName        = -- TODO: need translate!
 "Allows Unicode characters in name."
 config.runtime.nonstandardSymbol  = -- TODO: need translate!
 "Supports non-standard symbols. Make sure that your runtime environment supports these symbols."
+config.runtime.nonstandardSymbolTypes = -- TODO: need translate!
+"Override the type for non-standard symbols."
 config.runtime.plugin             = -- TODO: need translate!
 "Plugin path. Please read [wiki](https://luals.github.io/wiki/plugins) to learn more."
 config.runtime.pluginArgs         = -- TODO: need translate!

--- a/locale/zh-cn/setting.lua
+++ b/locale/zh-cn/setting.lua
@@ -26,6 +26,8 @@ config.runtime.unicodeName        =
 "允许在名字中使用 Unicode 字符。"
 config.runtime.nonstandardSymbol  =
 "支持非标准的符号。请务必确认你的运行环境支持这些符号。"
+config.runtime.nonstandardSymbolTypes = -- TODO: need translate!
+"Override the type for non-standard symbols."
 config.runtime.plugin             =
 "插件路径，请查阅[文档](https://luals.github.io/wiki/plugins)了解用法。"
 config.runtime.pluginArgs         = -- TODO: need translate!

--- a/locale/zh-tw/setting.lua
+++ b/locale/zh-tw/setting.lua
@@ -26,6 +26,8 @@ config.runtime.unicodeName        =
 "允許在名字中使用 Unicode 字元。"
 config.runtime.nonstandardSymbol  =
 "支援非標準的符號。請務必確認你的執行環境支援這些符號。"
+config.runtime.nonstandardSymbolTypes = -- TODO: need translate!
+"Override the type for non-standard symbols."
 config.runtime.plugin             =
 "延伸模組路徑，請查閱[文件](https://luals.github.io/wiki/plugins)瞭解用法。"
 config.runtime.pluginArgs         = -- TODO: need translate!

--- a/script/config/template.lua
+++ b/script/config/template.lua
@@ -224,15 +224,8 @@ local template = {
                                                 'continue',
                                             }),
     ['Lua.runtime.nonstandardSymbolTypes']  = Type.Hash(
-                                                Type.String,
-                                                Type.String >> '`' << {
-                                                    '//', '/**/',
-                                                    '`',
-                                                    '+=', '-=', '*=', '/=', '%=', '^=', '//=',
-                                                    '|=', '&=', '<<=', '>>=',
-                                                    '||', '&&', '!', '!=',
-                                                    'continue',
-                                                }
+                                                Type.String << { "`" },
+                                                Type.String >> "string"
                                             ),
     ['Lua.runtime.plugin']                  = Type.String,
     ['Lua.runtime.pluginArgs']              = Type.Array(Type.String),

--- a/script/config/template.lua
+++ b/script/config/template.lua
@@ -223,6 +223,17 @@ local template = {
                                                 '||', '&&', '!', '!=',
                                                 'continue',
                                             }),
+    ['Lua.runtime.nonstandardSymbolTypes']  = Type.Hash(
+                                                Type.String,
+                                                Type.String >> '`' << {
+                                                    '//', '/**/',
+                                                    '`',
+                                                    '+=', '-=', '*=', '/=', '%=', '^=', '//=',
+                                                    '|=', '&=', '<<=', '>>=',
+                                                    '||', '&&', '!', '!=',
+                                                    'continue',
+                                                }
+                                            ),
     ['Lua.runtime.plugin']                  = Type.String,
     ['Lua.runtime.pluginArgs']              = Type.Array(Type.String),
     ['Lua.runtime.fileEncoding']            = Type.String >> 'utf8' << {

--- a/script/files.lua
+++ b/script/files.lua
@@ -17,6 +17,7 @@ local lazy     = require 'lazytable'
 local cacher   = require 'lazy-cacher'
 local sp       = require 'bee.subprocess'
 local pub      = require 'pub'
+local json       = require 'json'
 
 ---@class file
 ---@field uri           uri
@@ -677,6 +678,8 @@ function m.compileState(uri)
         nonstandardSymbol = util.arrayToHash(config.get(uri, 'Lua.runtime.nonstandardSymbol')),
         nonstandardSymbolTypes = config.get(uri, 'Lua.runtime.nonstandardSymbolTypes'),
     }
+
+    log.info(json.encode(options.nonstandardSymbolTypes), json.encode(options.nonstandardSymbol))
 
     local ws     = require 'workspace'
     local client = require 'client'

--- a/script/files.lua
+++ b/script/files.lua
@@ -631,6 +631,7 @@ function m.compileStateAsync(uri, callback)
         special           = config.get(uri, 'Lua.runtime.special'),
         unicodeName       = config.get(uri, 'Lua.runtime.unicodeName'),
         nonstandardSymbol = util.arrayToHash(config.get(uri, 'Lua.runtime.nonstandardSymbol')),
+        nonstandardSymbolTypes = config.get(uri, 'Lua.runtime.nonstandardSymbolTypes'),
     }
 
     ---@type brave.param.compile
@@ -674,6 +675,7 @@ function m.compileState(uri)
         special           = config.get(uri, 'Lua.runtime.special'),
         unicodeName       = config.get(uri, 'Lua.runtime.unicodeName'),
         nonstandardSymbol = util.arrayToHash(config.get(uri, 'Lua.runtime.nonstandardSymbol')),
+        nonstandardSymbolTypes = config.get(uri, 'Lua.runtime.nonstandardSymbolTypes'),
     }
 
     local ws     = require 'workspace'

--- a/script/parser/compile.lua
+++ b/script/parser/compile.lua
@@ -1167,7 +1167,7 @@ local function parseShortString()
         end
     end
 
-    if State.options.nonstandardSymbolTypes[mark] then
+    if State.options.nonstandardSymbolTypes and State.options.nonstandardSymbolTypes[mark] then
         str.type = State.options.nonstandardSymbolTypes[mark]
     end
 

--- a/script/parser/compile.lua
+++ b/script/parser/compile.lua
@@ -1166,6 +1166,11 @@ local function parseShortString()
             }
         end
     end
+
+    if State.options.nonstandardSymbolTypes[mark] then
+        str.type = State.options.nonstandardSymbolTypes[mark]
+    end
+
     return str
 end
 


### PR DESCRIPTION
I'm not sure if I covered everything in the changes given.

But this feature would be helpful for FiveM development, since the backticks (`) are used for compile time hashing, so the type of that would be an integer and not string, this is causing some warnings here and there in code.


Let me know if I've missed anything or if anything else needs to be done for this pull request to be merged.