### PR TITLE
Make `workspace.checkThirdParty` a string enum

### DIFF
--- a/doc/en-us/config.md
+++ b/doc/en-us/config.md
@@ -2173,20 +2173,19 @@ Automatic detection and adaptation of third-party libraries, currently supported
 * skynet
 * Jass
 
-Value can be one of:
-* `Ask` (ask every time)
-* `Apply` (always apply third-party libraries and set the workspace
-  configuration)
-* `ApplyInMemory` (always apply third-party libraries but don't set the
-  workspace configuration)
-* `Disable` (don't ask and don't apply)
-
 
 ## type
 
 ```ts
 string
 ```
+
+## enum
+
+* ``"Ask"``
+* ``"Apply"``
+* ``"ApplyInMemory"``
+* ``"Disable"``
 
 ## default
 

--- a/doc/en-us/config.md
+++ b/doc/en-us/config.md
@@ -2173,17 +2173,25 @@ Automatic detection and adaptation of third-party libraries, currently supported
 * skynet
 * Jass
 
+Value can be one of:
+* `Ask` (ask every time)
+* `Apply` (always apply third-party libraries and set the workspace
+  configuration)
+* `ApplyInMemory` (always apply third-party libraries but don't set the
+  workspace configuration)
+* `Disable` (don't ask and don't apply)
+
 
 ## type
 
 ```ts
-boolean
+string
 ```
 
 ## default
 
 ```jsonc
-true
+"Ask"
 ```
 
 # workspace.ignoreDir

--- a/doc/pt-br/config.md
+++ b/doc/pt-br/config.md
@@ -2173,17 +2173,24 @@ Automatic detection and adaptation of third-party libraries, currently supported
 * skynet
 * Jass
 
+Value can be one of:
+* `Ask` (ask every time)
+* `Apply` (always apply third-party libraries and set the workspace
+  configuration)
+* `ApplyInMemory` (always apply third-party libraries but don't set the
+  workspace configuration)
+* `Disable` (don't ask and don't apply)
 
 ## type
 
 ```ts
-boolean
+string
 ```
 
 ## default
 
 ```jsonc
-true
+"Ask"
 ```
 
 # workspace.ignoreDir

--- a/doc/pt-br/config.md
+++ b/doc/pt-br/config.md
@@ -2173,19 +2173,19 @@ Automatic detection and adaptation of third-party libraries, currently supported
 * skynet
 * Jass
 
-Value can be one of:
-* `Ask` (ask every time)
-* `Apply` (always apply third-party libraries and set the workspace
-  configuration)
-* `ApplyInMemory` (always apply third-party libraries but don't set the
-  workspace configuration)
-* `Disable` (don't ask and don't apply)
 
 ## type
 
 ```ts
 string
 ```
+
+## enum
+
+* ``"Ask"``
+* ``"Apply"``
+* ``"ApplyInMemory"``
+* ``"Disable"``
 
 ## default
 

--- a/doc/zh-cn/config.md
+++ b/doc/zh-cn/config.md
@@ -2172,17 +2172,25 @@ true
 * skynet
 * Jass
 
+Value can be one of:
+* `Ask` (ask every time)
+* `Apply` (always apply third-party libraries and set the workspace
+  configuration)
+* `ApplyInMemory` (always apply third-party libraries but don't set the
+  workspace configuration)
+* `Disable` (don't ask and don't apply)
+
 
 ## type
 
 ```ts
-boolean
+string
 ```
 
 ## default
 
 ```jsonc
-true
+"Ask"
 ```
 
 # workspace.ignoreDir

--- a/doc/zh-cn/config.md
+++ b/doc/zh-cn/config.md
@@ -2172,20 +2172,19 @@ true
 * skynet
 * Jass
 
-Value can be one of:
-* `Ask` (ask every time)
-* `Apply` (always apply third-party libraries and set the workspace
-  configuration)
-* `ApplyInMemory` (always apply third-party libraries but don't set the
-  workspace configuration)
-* `Disable` (don't ask and don't apply)
-
 
 ## type
 
 ```ts
 string
 ```
+
+## enum
+
+* ``"Ask"``
+* ``"Apply"``
+* ``"ApplyInMemory"``
+* ``"Disable"``
 
 ## default
 

--- a/doc/zh-tw/config.md
+++ b/doc/zh-tw/config.md
@@ -2172,17 +2172,24 @@ true
 * skynet
 * Jass
 
+Value can be one of:
+* `Ask` (ask every time)
+* `Apply` (always apply third-party libraries and set the workspace
+  configuration)
+* `ApplyInMemory` (always apply third-party libraries but don't set the
+  workspace configuration)
+* `Disable` (don't ask and don't apply)
 
 ## type
 
 ```ts
-boolean
+string
 ```
 
 ## default
 
 ```jsonc
-true
+"Ask"
 ```
 
 # workspace.ignoreDir

--- a/doc/zh-tw/config.md
+++ b/doc/zh-tw/config.md
@@ -2172,19 +2172,19 @@ true
 * skynet
 * Jass
 
-Value can be one of:
-* `Ask` (ask every time)
-* `Apply` (always apply third-party libraries and set the workspace
-  configuration)
-* `ApplyInMemory` (always apply third-party libraries but don't set the
-  workspace configuration)
-* `Disable` (don't ask and don't apply)
 
 ## type
 
 ```ts
 string
 ```
+
+## enum
+
+* ``"Ask"``
+* ``"Apply"``
+* ``"ApplyInMemory"``
+* ``"Disable"``
 
 ## default
 

--- a/script/config/template.lua
+++ b/script/config/template.lua
@@ -317,7 +317,12 @@ local template = {
     ['Lua.workspace.maxPreload']            = Type.Integer >> 5000,
     ['Lua.workspace.preloadFileSize']       = Type.Integer >> 500,
     ['Lua.workspace.library']               = Type.Array(Type.String),
-    ['Lua.workspace.checkThirdParty']       = Type.Boolean >> true,
+    ['Lua.workspace.checkThirdParty']       = Type.String >> 'Ask' << {
+                                                'Ask',
+                                                'Apply',
+                                                'ApplyInMemory',
+                                                'Disable',
+                                            },
     ['Lua.workspace.userThirdParty']        = Type.Array(Type.String),
     ['Lua.completion.enable']               = Type.Boolean >> true,
     ['Lua.completion.callSnippet']          = Type.String  >> 'Disable' << {


### PR DESCRIPTION
This lets you skip the "apply third party library to workspace configuration" prompt.

The value of `Lua.workspace.checkThirdParty` can now be one of:
* `Ask` (ask every time; this is equivalent to `true`)
* `Apply` (always apply third-party libraries and set the workspace
  configuration)
* `ApplyInMemory` (always apply third-party libraries but don't set the
  workspace configuration)
* `Disable` (don't ask and don't apply; this is equivalent to `false`)

Backwards compatibility with the old boolean configuration values is maintained; `true` is treated as `Ask` and `false` is treated as `Disable`.

I need some help translating the Taiwanese, Mandarin, and Portugese, but I copied the English in there as a standin -- presumably it's better to have some documentation in the wrong language which can be machine-translated than to have missing information.

I've built and tested this on my machine.