### PR TITLE
Add `--check_out_path` CLI argument

### DIFF
--- a/script/cli/check.lua
+++ b/script/cli/check.lua
@@ -99,7 +99,10 @@ end
 if count == 0 then
     print(lang.script('CLI_CHECK_SUCCESS'))
 else
-    local outpath = LOGPATH .. '/check.json'
+    local outpath = CHECK_OUT_PATH
+    if outpath == nil then
+        outpath = LOGPATH .. '/check.json'
+    end
     util.saveFile(outpath, jsonb.beautify(results))
 
     print(lang.script('CLI_CHECK_RESULTS', count, outpath))

--- a/script/global.d.lua
+++ b/script/global.d.lua
@@ -55,6 +55,12 @@ DOC = ''
 ---@type string | '"Error"' | '"Warning"' | '"Information"' | '"Hint"'
 CHECKLEVEL = 'Warning'
 
+--Where to write the check results (JSON).
+--
+--If nil, use `LOGPATH/check.json`.
+---@type string|nil
+CHECK_OUT_PATH = ''
+
 ---@type 'trace' | 'debug' | 'info' | 'warn' | 'error'
 LOGLEVEL = 'warn'
 


### PR DESCRIPTION
This allows customizing where the diagnostic JSON file is saved.