### PR TITLE
Prefer https submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -57,7 +57,7 @@
 	url = https://github.com/LuaCATS/skynet.git
 [submodule "meta/3rd/ffi-reflect"]
 	path = meta/3rd/ffi-reflect
-	url = git@github.com:LuaCATS/ffi-reflect.git
+  url = https://github.com/LuaCATS/ffi-reflect.git
 [submodule "meta/3rd/luv"]
 	path = meta/3rd/luv
-	url = git@github.com:LuaCATS/luv.git
+  url = https://github.com/LuaCATS/luv.git


### PR DESCRIPTION
Submodules that have `git@github.com:person/repo` url don't work when ssh or ssh keys are not set up properly, for example in minimal automated build environments like Nix. Use the `https://github/person/repo` url instead for more compatibility.

Closes #2396