### PR TITLE
Fix backwards compatability with `Lua.workspace.checkThirdParty`

### DIFF
--- a/script/library.lua
+++ b/script/library.lua
@@ -610,9 +610,13 @@ local function check3rd(uri)
     end
     local checkThirdParty = config.get(uri, 'Lua.workspace.checkThirdParty')
     -- Backwards compatability: `checkThirdParty` used to be a boolean.
-    if not checkThirdParty or checkThirdParty == 'Disable' then
+    -- Note: `checkThirdParty` is defined as a string, so if a boolean is
+    -- supplied, it's converted to a string by the `config.config` module.
+    -- Hence we check for the strings `'true'` and `'false`' here, rather than
+    -- the boolean literals.
+    if checkThirdParty == 'Disable' or checkThirdParty == 'false' then
         return
-    elseif checkThirdParty == true then
+    elseif checkThirdParty == 'true' then
         checkThirdParty = 'Ask'
     end
     local scp = scope.getScope(uri)


### PR DESCRIPTION
I attempted to maintain backwards compatibility in #2354 but didn't fully understand the config type system. Here I checked for the booleans `true` and `false`:

https://github.com/LuaLS/lua-language-server/blob/3bbc8dd579dadd67171c758c1065f271c5816133/script/library.lua#L611-L617

But the config value is now defined as a string:

https://github.com/LuaLS/lua-language-server/blob/5a763b0ceecc9a817c8ce534dc726f5f6f6e1ac9/script/config/template.lua#L320-L325

So when the config is loaded as a boolean, it gets converted to a string:

https://github.com/LuaLS/lua-language-server/blob/5a763b0ceecc9a817c8ce534dc726f5f6f6e1ac9/script/config/template.lua#L81-L85

We can fix this by checking for the string values `'true'` and `'false'`, rather than the boolean values `true` and `false`.