### PR TITLE
Fix backwards compatability with `Lua.workspace.checkThirdParty` (take 2!)

### DIFF
--- a/script/config/template.lua
+++ b/script/config/template.lua
@@ -317,12 +317,12 @@ local template = {
     ['Lua.workspace.maxPreload']            = Type.Integer >> 5000,
     ['Lua.workspace.preloadFileSize']       = Type.Integer >> 500,
     ['Lua.workspace.library']               = Type.Array(Type.String),
-    ['Lua.workspace.checkThirdParty']       = Type.String >> 'Ask' << {
+    ['Lua.workspace.checkThirdParty']       = Type.Or(Type.String >> 'Ask' << {
                                                 'Ask',
                                                 'Apply',
                                                 'ApplyInMemory',
                                                 'Disable',
-                                            },
+                                            }, Type.Boolean),
     ['Lua.workspace.userThirdParty']        = Type.Array(Type.String),
     ['Lua.completion.enable']               = Type.Boolean >> true,
     ['Lua.completion.callSnippet']          = Type.String  >> 'Disable' << {

--- a/script/library.lua
+++ b/script/library.lua
@@ -610,13 +610,9 @@ local function check3rd(uri)
     end
     local checkThirdParty = config.get(uri, 'Lua.workspace.checkThirdParty')
     -- Backwards compatability: `checkThirdParty` used to be a boolean.
-    -- Note: `checkThirdParty` is defined as a string, so if a boolean is
-    -- supplied, it's converted to a string by the `config.config` module.
-    -- Hence we check for the strings `'true'` and `'false`' here, rather than
-    -- the boolean literals.
-    if checkThirdParty == 'Disable' or checkThirdParty == 'false' then
+    if not checkThirdParty or checkThirdParty == 'Disable' then
         return
-    elseif checkThirdParty == 'true' then
+    elseif checkThirdParty == true then
         checkThirdParty = 'Ask'
     end
     local scp = scope.getScope(uri)


### PR DESCRIPTION
I attempted to maintain backwards compatability in https://github.com/LuaLS/lua-language-server/pull/2354 and https://github.com/LuaLS/lua-language-server/pull/2406 but didn't fully understand the config type system.

This approach uses `Type.Or` and I even tested it to confirm that it works!

Thanks to @pysan3 for pointing out how a default would be used for invalid types (https://github.com/LuaLS/lua-language-server/pull/2406#issuecomment-1802337591), and thanks to @sumneko for pointing out `Type.Or` (https://github.com/LuaLS/lua-language-server/pull/2406#issuecomment-1802353877).