### PR TITLE
bit meta: tohex returns a string

### DIFF
--- a/meta/template/bit.lua
+++ b/meta/template/bit.lua
@@ -12,7 +12,7 @@ function bit.tobit(x) end
 
 ---@param x  integer
 ---@param n? integer
----@return integer y
+---@return string y
 ---@nodiscard
 function bit.tohex(x, n) end
 


### PR DESCRIPTION
LuaJIT's `bit.tohex` returns a string value of the decimal number formatted as a hexadecimal not an integer value. 