### PR TITLE
Config settings for path/filename of doc files.

### DIFF
--- a/script/cli/doc2md.lua
+++ b/script/cli/doc2md.lua
@@ -4,11 +4,19 @@
 local jsonc    = require 'jsonc'
 local util     = require 'utility'
 local markdown = require 'provider.markdown'
+local config   = require 'config'
+local ws       = require 'workspace'
+local fs       = require 'bee.filesystem'
 
 local export = {}
 
 function export.buildMD(outputPath)
-    local doc = jsonc.decode_jsonc(util.loadFile(outputPath .. '/doc.json'))
+    local jsonPath = fs.canonical(
+       outputPath .. '/' .. config.get(ws.rootUri, 'Lua.doc.output.filenameJSON')):string()
+    local mdPath = fs.canonical(
+       outputPath .. '/' .. config.get(ws.rootUri, 'Lua.doc.output.filenameMD')):string()
+
+    local doc = jsonc.decode_jsonc(util.loadFile(jsonPath))
     local md  = markdown()
 
     assert(type(doc) == 'table')
@@ -42,8 +50,6 @@ function export.buildMD(outputPath)
         end
         md:splitLine()
     end
-
-    local mdPath = outputPath .. '/doc.md'
 
     util.saveFile(mdPath, md:string())
 

--- a/script/config/template.lua
+++ b/script/config/template.lua
@@ -400,6 +400,9 @@ local template = {
     ['Lua.doc.privateName']                 = Type.Array(Type.String),
     ['Lua.doc.protectedName']               = Type.Array(Type.String),
     ['Lua.doc.packageName']                 = Type.Array(Type.String),
+    ['Lua.doc.output.path']                 = Type.String,
+    ['Lua.doc.output.filenameJSON']         = Type.String >> 'doc.json',
+    ['Lua.doc.output.filenameMD']           = Type.String >> 'doc.md',
 
     -- VSCode
     ["Lua.addonManager.enable"]             = Type.Boolean >> true,

--- a/script/core/command/exportDocument.lua
+++ b/script/core/command/exportDocument.lua
@@ -7,7 +7,7 @@ local files  = require 'files'
 
 ---@async
 return function (args)
-    local outputPath = args[1] and furi.decode(args[1]) or LOGPATH
+    local outputPath = args[1] and furi.decode(args[1]) or doc.outputPath()
     local docPath, mdPath = doc.makeDoc(outputPath)
     client.showMessage('Info', lang.script('CLI_DOC_DONE'
         , ('[%s](%s)'):format(files.normalize(docPath), furi.encode(docPath))


### PR DESCRIPTION
* Added 3 new configuration settings:
  - Lua.doc.output.path
  - Lua.doc.output.filenameJSON
  - Lua.doc.output.filenameMD

* Documentation files will be saved in the given path/filename locations.

* Default behavior: Not changed. If settings are missing, files will be saved in LOGPATH.