### PR TITLE
CLI option --doc_out_path <PATH>.

### DIFF
--- a/script/cli/doc.lua
+++ b/script/cli/doc.lua
@@ -292,6 +292,18 @@ function export.export(outputPath, callback)
     return docPath, mdPath
 end
 
+function export.getDocOutputPath()
+    local doc_output_path = ''
+    if type(DOC_OUT_PATH) == 'string' then
+        doc_output_path = fs.absolute(fs.path(DOC_OUT_PATH)):string()
+    elseif DOC_OUT_PATH == true then
+        doc_output_path = fs.current_path():string()
+    else
+        doc_output_path = LOGPATH
+    end
+    return doc_output_path
+end
+
 ---@async
 ---@param outputPath string
 function export.makeDoc(outputPath)
@@ -350,7 +362,7 @@ function export.runCLI()
         ws.awaitReady(rootUri)
         await.sleep(0.1)
 
-        local docPath, mdPath = export.export(LOGPATH, function (i, max)
+        local docPath, mdPath = export.export(export.getDocOutputPath(), function (i, max)
             if os.clock() - lastClock > 0.2 then
                 lastClock = os.clock()
                 local output = '\x0D'

--- a/script/global.d.lua
+++ b/script/global.d.lua
@@ -52,6 +52,10 @@ CHECK = ''
 ---@type string
 DOC = ''
 
+--output directory path for documentation (doc.json, ...)
+---@type string
+DOC_OUT_PATH = ''
+
 ---@type string | '"Error"' | '"Warning"' | '"Information"' | '"Hint"'
 CHECKLEVEL = 'Warning'
 


### PR DESCRIPTION
CLI option --doc_out_path <PATH>.

This CLI option specifies the output directory path for documentation files (eg. 'doc.json').