### PR TITLE
Enable plugins during --check

### DIFF
--- a/script/cli/check.lua
+++ b/script/cli/check.lua
@@ -11,6 +11,7 @@ local config   = require 'config.config'
 local fs       = require 'bee.filesystem'
 local provider = require 'provider'
 
+require 'plugin'
 require 'vm'
 
 lang(LOCALE)

--- a/script/plugin.lua
+++ b/script/plugin.lua
@@ -146,6 +146,7 @@ local function initPlugin(uri)
             return
         end
         local args = config.get(scp.uri, 'Lua.runtime.pluginArgs')
+        if args == nil then args = {} end
         if type(pluginConfigPaths) == 'string' then
             pluginConfigPaths = { pluginConfigPaths }
         end


### PR DESCRIPTION
Diagnostics reports provided by `lua-language-server --check .` currently does not use plugins.

For some complex projects, plugins are required for proper type annotations.

To fix this:
1. require plugin to add the 'startReload' / 'initPlugin'  callback to the workspace watchlist
2. in a previous PR, pluginargs was changed to support multiple plugins.  Previously it had 1 default type, but now it has 2.  This means that the default `get` returns nil instead of an empty table.  To smooth this transition, I set it to `{}` when it is `nil`.