### PR TITLE
Only load files in workspace for --check (skip libraries)

### DIFF
--- a/script/cli/check.lua
+++ b/script/cli/check.lua
@@ -27,6 +27,7 @@ if not rootUri then
     print(lang.script('CLI_CHECK_ERROR_URI', rootPath))
     return
 end
+rootUri = rootUri:gsub("/$", "")
 
 if CHECKLEVEL then
     if not define.DiagnosticSeverity[CHECKLEVEL] then
@@ -70,7 +71,7 @@ lclient():start(function (client)
     end
     config.set(rootUri, 'Lua.diagnostics.disable', util.getTableKeys(disables, true))
 
-    local uris = files.getAllUris(rootUri)
+    local uris = files.getChildFiles(rootUri)
     local max  = #uris
     for i, uri in ipairs(uris) do
         files.open(uri)


### PR DESCRIPTION
The current behavior of --check is to run diagnostics on all files that are loaded including defined libraries. I believe checking libraries is undesirable because:

1. you might not own the code in there and any warning triggered in there can be non-actionable for you
2. libraries can be very large and make check take a long time. For our project it adds about 2 minutes of time to check libraries and get warnings we can't do anything about anyways


Please let me know if you would prefer this behavior to be customizable instead, but I believe the current behavior is just undesirable in general.