### PR TITLE
Flush stdout in check progress indicator

### DIFF
--- a/script/cli/check.lua
+++ b/script/cli/check.lua
@@ -84,6 +84,7 @@ lclient():start(function (client)
                         .. ('0'):rep(#tostring(max) - #tostring(i))
                         .. tostring(i) .. '/' .. tostring(max)
             io.write(output)
+            io.flush()
         end
     end
     io.write('\x0D')


### PR DESCRIPTION
stdout is often line-buffered and needs flushing for the progress indicator to work