### PR TITLE
Allow plugins to resolve require paths

### DIFF
--- a/script/plugin.lua
+++ b/script/plugin.lua
@@ -27,7 +27,7 @@ function m.showError(scp, err)
     client.showMessage('Error', lang.script('PLUGIN_RUNTIME_ERROR', scp:get('pluginPath'), err))
 end
 
----@alias plugin.event 'OnSetText' | 'OnTransformAst'
+---@alias plugin.event 'OnSetText' | 'OnTransformAst' | 'ResolveRequire'
 
 ---@param event plugin.event
 function m.dispatch(event, uri, ...)

--- a/script/workspace/require-path.lua
+++ b/script/workspace/require-path.lua
@@ -5,6 +5,7 @@ local workspace = require "workspace"
 local config    = require 'config'
 local scope     = require 'workspace.scope'
 local util      = require 'utility'
+local plugin    = require 'plugin'
 
 ---@class require-path
 local m = {}
@@ -180,6 +181,11 @@ function mt:searchUrisByRequireName(name)
     local results     = {}
     local searcherMap = {}
     local excludes    = {}
+
+    local pluginSuccess, pluginResults = plugin.dispatch('ResolveRequire', self.scp.uri, name)
+    if pluginSuccess and pluginResults ~= nil then
+        return pluginResults
+    end
 
     for uri in files.eachFile(self.scp.uri) do
         if vm.isMetaFileRequireable(uri) then


### PR DESCRIPTION
This PR allows plugins to manually resolve `require('...')` file paths. It adds `ResolveRequire` plugin method, that accepts workspace URI and require name, and can return resolved paths to Lua files.  

This feature would be helpful for environments that implement custom `require` name resolution, as it provides max flexibility and can be added with an addon.

## Example usage

```lua
---@param uri string
---@param name string
---@return nil|string[]
function ResolveRequire(uri, name)
  if name:byte(1) ~= 0x40 --[['@']] then
      return nil
  end

  return { "file:///path/to/mods/" .. name:sub(2) .. "/main.lua" }
end
```