### PR TITLE
Fix typo in config.json

### DIFF
--- a/meta/3rd/example/config.json
+++ b/meta/3rd/example/config.json
@@ -5,7 +5,7 @@
     "words"   : ["thisIsAnExampleWord%.ifItExistsInFile%.thenTryLoadThisLibrary"],
     // list or matched file names. `.lua`, `.dll` and `.so` only
     "files"   : ["thisIsAnExampleFile%.ifItExistsInWorkSpace%.thenTryLoadThisLibrary%.lua"],
-    // lsit of settings to be changed
+    // list of settings to be changed
     "settings"  : {
         "Lua.runtime.version" : "LuaJIT",
         "Lua.diagnostics.globals" : [


### PR DESCRIPTION
I noticed a typo in meta/3rd/example/config.json while figuring out how to add the Scrap Mechanic library in Kate

This is my first pull request, so if I did anything wrong please let me know