### PR TITLE
Run diagnostics on unopened files when explicitly requested by the user

### DIFF
--- a/script/core/diagnostics/init.lua
+++ b/script/core/diagnostics/init.lua
@@ -94,8 +94,9 @@ end
 ---@param name string
 ---@param isScopeDiag boolean
 ---@param response async fun(result: any)
+---@param ignoreFileOpenState? boolean
 ---@return boolean
-local function check(uri, name, isScopeDiag, response)
+local function check(uri, name, isScopeDiag, response, ignoreFileOpenState)
     local disables = config.get(uri, 'Lua.diagnostics.disable')
     if util.arrayHas(disables, name) then
         return false
@@ -107,7 +108,7 @@ local function check(uri, name, isScopeDiag, response)
         return false
     end
 
-    if status == 'Opened' and not files.isOpen(uri) then
+    if not ignoreFileOpenState and status == 'Opened' and not files.isOpen(uri) then
         return false
     end
 
@@ -167,7 +168,8 @@ end
 ---@param isScopeDiag boolean
 ---@param response async fun(result: any)
 ---@param checked? async fun(name: string)
-return function (uri, isScopeDiag, response, checked)
+---@param ignoreFileOpenState? boolean
+return function (uri, isScopeDiag, response, checked, ignoreFileOpenState)
     local ast = files.getState(uri)
     if not ast then
         return nil
@@ -176,7 +178,7 @@ return function (uri, isScopeDiag, response, checked)
     for _, name in ipairs(buildDiagList()) do
         await.delay()
         local clock = os.clock()
-        local suc = check(uri, name, isScopeDiag, response)
+        local suc = check(uri, name, isScopeDiag, response, ignoreFileOpenState)
         if suc then
             local cost = os.clock() - clock
             diagCosts[name] = (diagCosts[name] or 0) + cost

--- a/script/provider/diagnostic.lua
+++ b/script/provider/diagnostic.lua
@@ -275,7 +275,7 @@ local function isValid(uri)
 end
 
 ---@async
-function m.doDiagnostic(uri, isScopeDiag)
+function m.doDiagnostic(uri, isScopeDiag, ignoreFileState)
     if not isValid(uri) then
         return
     end
@@ -348,7 +348,7 @@ function m.doDiagnostic(uri, isScopeDiag)
                 lastDiag[#lastDiag] = nil
             end
         end
-    end)
+    end, ignoreFileState)
 
     lastDiag = nil
     pushResult()
@@ -575,7 +575,7 @@ function m.awaitDiagnosticsScope(suri, callback)
     finished = true
 end
 
-function m.diagnosticsScope(uri, force)
+function m.diagnosticsScope(uri, force, ignoreFileOpenState)
     if not ws.isReady(uri) then
         return
     end
@@ -592,7 +592,7 @@ function m.diagnosticsScope(uri, force)
     await.call(function () ---@async
         await.sleep(0.0)
         m.awaitDiagnosticsScope(uri, function (fileUri)
-            xpcall(m.doDiagnostic, log.error, fileUri, true)
+            xpcall(m.doDiagnostic, log.error, fileUri, true, ignoreFileOpenState)
         end)
     end, id)
 end

--- a/script/provider/provider.lua
+++ b/script/provider/provider.lua
@@ -1209,7 +1209,7 @@ m.register '$/status/click' {
         if result == titleDiagnostic then
             local diagnostic = require 'provider.diagnostic'
             for _, scp in ipairs(workspace.folders) do
-                diagnostic.diagnosticsScope(scp.uri, true)
+                diagnostic.diagnosticsScope(scp.uri, true, true)
             end
         elseif result == 'Restart Server' then
             local diag = require 'provider.diagnostic'


### PR DESCRIPTION
If I explicitly click on "Diagnose workspace" I would expect it to show me *all* the diagnostics similar to how --check in a CI would check my project.

This makes it easier for users to check their whole workspace after making changes to some library or core function that potentially affects a large number of files that are usually only checked once opened.