### PR TITLE
Add setting to find globals using regex

### DIFF
--- a/doc/en-us/config.md
+++ b/doc/en-us/config.md
@@ -406,6 +406,22 @@ Array<string>
 []
 ```
 
+# diagnostics.globalsRegex
+
+Find defined global variables using regex.
+
+## type
+
+```ts
+Array<string>
+```
+
+## default
+
+```jsonc
+[]
+```
+
 # diagnostics.groupFileStatus
 
 Modify the diagnostic needed file status in a group.

--- a/doc/pt-br/config.md
+++ b/doc/pt-br/config.md
@@ -406,6 +406,22 @@ Array<string>
 []
 ```
 
+# diagnostics.globalsRegex
+
+Find defined global variables using regex.
+
+## type
+
+```ts
+Array<string>
+```
+
+## default
+
+```jsonc
+[]
+```
+
 # diagnostics.groupFileStatus
 
 Modify the diagnostic needed file status in a group.

--- a/doc/zh-cn/config.md
+++ b/doc/zh-cn/config.md
@@ -406,6 +406,22 @@ Array<string>
 []
 ```
 
+# diagnostics.globalsRegex
+
+Find defined global variables using regex.
+
+## type
+
+```ts
+Array<string>
+```
+
+## default
+
+```jsonc
+[]
+```
+
 # diagnostics.groupFileStatus
 
 批量修改一个组中的文件状态。

--- a/doc/zh-tw/config.md
+++ b/doc/zh-tw/config.md
@@ -406,6 +406,22 @@ Array<string>
 []
 ```
 
+# diagnostics.globalsRegex
+
+Find defined global variables using regex.
+
+## type
+
+```ts
+Array<string>
+```
+
+## default
+
+```jsonc
+[]
+```
+
 # diagnostics.groupFileStatus
 
 批量修改一個組中的檔案狀態。

--- a/locale/en-us/setting.lua
+++ b/locale/en-us/setting.lua
@@ -48,6 +48,8 @@ config.diagnostics.disable        =
 "Disabled diagnostic (Use code in hover brackets)."
 config.diagnostics.globals        =
 "Defined global variables."
+config.diagnostics.globalsRegex   =
+"Find defined global variables using regex."
 config.diagnostics.severity       =
 [[
 Modify the diagnostic severity.

--- a/locale/pt-br/setting.lua
+++ b/locale/pt-br/setting.lua
@@ -48,6 +48,8 @@ config.diagnostics.disable        = -- TODO: need translate!
 "Disabled diagnostic (Use code in hover brackets)."
 config.diagnostics.globals        = -- TODO: need translate!
 "Defined global variables."
+config.diagnostics.globalsRegex   = -- TODO: need translate!
+"Find defined global variables using regex."
 config.diagnostics.severity       = -- TODO: need translate!
 [[
 Modify the diagnostic severity.

--- a/locale/zh-cn/setting.lua
+++ b/locale/zh-cn/setting.lua
@@ -48,6 +48,8 @@ config.diagnostics.disable        =
 "禁用的诊断（使用浮框括号内的代码）。"
 config.diagnostics.globals        =
 "已定义的全局变量。"
+config.diagnostics.globalsRegex   = -- TODO: need translate!
+"Find defined global variables using regex."
 config.diagnostics.severity       =
 [[
 修改诊断等级。

--- a/locale/zh-tw/setting.lua
+++ b/locale/zh-tw/setting.lua
@@ -48,6 +48,8 @@ config.diagnostics.disable        =
 "停用的診斷（使用浮框括號內的程式碼）。"
 config.diagnostics.globals        =
 "已定義的全域變數。"
+config.diagnostics.globalsRegex   = -- TODO: need translate!
+"Find defined global variables using regex."
 config.diagnostics.severity       =
 [[
 修改診斷等級。

--- a/script/config/template.lua
+++ b/script/config/template.lua
@@ -242,6 +242,7 @@ local template = {
                                             >> util.deepCopy(define.BuiltIn),
     ['Lua.diagnostics.enable']              = Type.Boolean >> true,
     ['Lua.diagnostics.globals']             = Type.Array(Type.String),
+    ['Lua.diagnostics.globalsRegex']        = Type.Array(Type.String),
     ['Lua.diagnostics.disable']             = Type.Array(Type.String << util.getTableKeys(diag.getDiagAndErrNameMap(), true)),
     ['Lua.diagnostics.severity']            = Type.Hash(
                                                 Type.String << util.getTableKeys(define.DiagnosticDefaultNeededFileStatus, true),

--- a/script/core/diagnostics/global-element.lua
+++ b/script/core/diagnostics/global-element.lua
@@ -17,6 +17,20 @@ local function isDocClass(source)
     return false
 end
 
+local function isGlobalRegex(name, definedGlobalRegex)
+    if not definedGlobalRegex then
+        return false
+    end
+
+    for _, pattern in ipairs(definedGlobalRegex) do
+        if name:match(pattern) then
+            return true
+        end
+    end
+
+    return false
+end
+
 -- If global elements are discouraged by coding convention, this diagnostic helps with reminding about that
 -- Exceptions may be added to Lua.diagnostics.globals
 return function (uri, callback)
@@ -26,6 +40,7 @@ return function (uri, callback)
     end
 
     local definedGlobal = util.arrayToHash(config.get(uri, 'Lua.diagnostics.globals'))
+    local definedGlobalRegex = config.get(uri, 'Lua.diagnostics.globalsRegex')
 
     guide.eachSourceType(ast.ast, 'setglobal', function (source)
         local name = guide.getKeyName(source)
@@ -34,6 +49,9 @@ return function (uri, callback)
         end
         -- If the assignment is marked as doc.class, then it is considered allowed 
         if isDocClass(source) then
+            return
+        end
+        if isGlobalRegex(name, definedGlobalRegex) then
             return
         end
         if definedGlobal[name] == nil then


### PR DESCRIPTION
I use the LuaLS for many years and all of these years I had disabled the undefined-global because my project use global envs, and in these envs I have some globals like "const_something" and "SOMETHING" in more than 1000 submodules. So I needed this feature to improve my project checking.

I also improved to avoid unecessary checks in checkIsUndefinedGlobal like create a table with all elements to check only one of them.

This is related to: https://github.com/LuaLS/lua-language-server/issues/2627

Exemple of config:
```
"Lua.diagnostics.globalsRegex": [
  "^const.*",
  "^[A-Z][A-Z0-9_]+$",
],
```