### PR TITLE
Fix linux-arm64 build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
         include:
           - { os: ubuntu-22.04,   target: linux,   platform: linux-x64,   container: 'alpine:latest', libc: musl }
           - { os: ubuntu-20.04,   target: linux,   platform: linux-x64    }
-          #- { os: ubuntu-20.04,   target: linux,   platform: linux-arm64  }
+          - { os: ubuntu-20.04,   target: linux,   platform: linux-arm64  }
           - { os: macos-11,       target: darwin,  platform: darwin-x64   }
           - { os: macos-11,       target: darwin,  platform: darwin-arm64 }
           - { os: windows-latest, target: windows, platform: win32-ia32   }
@@ -34,6 +34,12 @@ jobs:
     container:
       image: ${{ matrix.container }}
     steps:
+      - name: Install aarch64-linux-gnu
+        if: ${{ matrix.platform == 'linux-arm64' && matrix.libc != 'musl' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+
       - name: Prepare container for musl
         if: ${{ matrix.target == 'linux' && matrix.libc == 'musl' }}
         run: |


### PR DESCRIPTION
There were errors when running build workflow for linux-arm64, and no linux-arm64 binaries were built since 3.8.0 (#2626).

The build workflow can be fixed by using sudo for apt-get commands.