### PR TITLE
add: load ENV variables as args

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -2,6 +2,8 @@ local fs      = require 'bee.filesystem'
 local util    = require 'utility'
 local version = require 'version'
 
+require 'config.env'
+
 local function getValue(value)
     if     value == 'true' or value == nil then
         value = true

--- a/script/config/env.lua
+++ b/script/config/env.lua
@@ -1,0 +1,55 @@
+-- Handles loading environment arguments
+
+---ENV args are defined here.
+---- `name` is the ENV arg name
+---- `key` is the value used to index `_G` for setting the argument
+---@type { name: string, key: string }[]
+local vars = {
+    {
+        name = "LLS_CHECK_LEVEL",
+        key = "CHECKLEVEL",
+    },
+    {
+        name = "LLS_CHECK_PATH",
+        key = "CHECK",
+    },
+    {
+        name = "LLS_CONFIG_PATH",
+        key = "CONFIGPATH"
+    },
+    {
+        name = "LLS_DOC_OUT_PATH",
+        key = "DOC_OUT_PATH",
+    },
+    {
+        name = "LLS_DOC_PATH",
+        key = "DOC",
+    },
+    {
+        name = "LLS_FORCE_ACCEPT_WORKSPACE",
+        key = "FORCE_ACCEPT_WORKSPACE"
+    },
+    {
+        name = "LLS_LOCALE",
+        key = "LOCALE",
+    },
+    {
+        name = "LLS_LOG_LEVEL",
+        key = "LOGLEVEL",
+    },
+    {
+        name = "LLS_LOG_PATH",
+        key = "LOGPATH",
+    },
+    {
+        name = "LLS_META_PATH",
+        key = "METAPATH"
+    }
+}
+
+for _, var in ipairs(vars) do
+    local value = os.getenv(var.name)
+    if value then
+        _G[var.key] = value
+    end
+end

--- a/script/config/env.lua
+++ b/script/config/env.lua
@@ -1,9 +1,16 @@
 -- Handles loading environment arguments
 
+---Convert a string to boolean
+---@param v string
+local function strToBool(v)
+    return v == "true"
+end
+
 ---ENV args are defined here.
 ---- `name` is the ENV arg name
 ---- `key` is the value used to index `_G` for setting the argument
----@type { name: string, key: string }[]
+---- `converter` if present, will be used to convert the string value into another type
+---@type { name: string, key: string, converter: fun(value: string): any }[]
 local vars = {
     {
         name = "LLS_CHECK_LEVEL",
@@ -15,7 +22,7 @@ local vars = {
     },
     {
         name = "LLS_CONFIG_PATH",
-        key = "CONFIGPATH"
+        key = "CONFIGPATH",
     },
     {
         name = "LLS_DOC_OUT_PATH",
@@ -27,7 +34,8 @@ local vars = {
     },
     {
         name = "LLS_FORCE_ACCEPT_WORKSPACE",
-        key = "FORCE_ACCEPT_WORKSPACE"
+        key = "FORCE_ACCEPT_WORKSPACE",
+        converter = strToBool,
     },
     {
         name = "LLS_LOCALE",
@@ -43,13 +51,17 @@ local vars = {
     },
     {
         name = "LLS_META_PATH",
-        key = "METAPATH"
-    }
+        key = "METAPATH",
+    },
 }
 
 for _, var in ipairs(vars) do
     local value = os.getenv(var.name)
     if value then
+        if var.converter then
+            value = var.converter(value)
+        end
+
         _G[var.key] = value
     end
 end


### PR DESCRIPTION
This started off with me taking a look at implementing https://github.com/LuaLS/lua-language-server/issues/2330, but I am not sure how I would go about merging an ENV variable with a client configuration. Any tips on that would be great!

In the meantime, I have added loading of ENV variables for a bunch of the CLI args, as it was a pretty low-hanging fruit. So for example, instead of doing `./lua-language-server --doc="path/to/workspace"`, you can do `export LLS_DOC_PATH="path/to/workspace"` and then just run `./lua-language-server`.