### PR TITLE
build: use docker to build linux-x64 glibc

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,16 +51,22 @@ jobs:
           submodules: recursive
 
       - name: Build for others step-1
-        if: ${{ matrix.libc != 'musl' }}
+        if: ${{ matrix.platform != 'linux-x64' }}
         uses: actboy168/setup-luamake@master
 
       - name: Build for others step-2
-        if: ${{ matrix.libc != 'musl' }}
+        if: ${{ matrix.platform != 'linux-x64' }}
         run: luamake -platform ${{ matrix.platform }}
 
       - name: Build for musl
-        if: ${{ matrix.target == 'linux' && matrix.libc == 'musl' }}
+        if: ${{ matrix.platform == 'linux-x64' && matrix.libc == 'musl' }}
         run: ./make.sh
+
+      - name: Build for x64 glibc
+        if: ${{ matrix.platform == 'linux-x64' && matrix.libc != 'musl' }}
+        run: |
+          docker build -t ubuntu-18.04 .
+          docker run --rm -v $(pwd):$(pwd) -w $(pwd) ubuntu-18.04 bash -c './make.sh'
 
       - name: Setting up workflow variables
         id: vars

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# Dockerfile
+
+FROM ubuntu:18.04
+
+# Install necessary packages
+RUN apt-get update && \
+    apt-get install -y software-properties-common && \
+    add-apt-repository -y ppa:ubuntu-toolchain-r/test && \
+    add-apt-repository -y ppa:git-core/ppa && \
+    apt-get install -y git gcc-9 g++-9 wget tar gzip rsync ninja-build
+
+# Use alternative gcc
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 100 && \
+    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 100


### PR DESCRIPTION
Similar fix to #1835, but uses independent docker environment instead of GitHub Workflow container. Fixes the issue #1828.

The `action/checkout@v4` uses `node20` depends on newer GLIBC version, which is not available in old docker image, e.g., `ubuntu-18.04`. We don't want the image has newer version of glibc because we want to build binary using older version of GLIBC. Because the container will be evoked at start of the job, using `action/checkout@v4` causes the [errors](https://github.com/LuaLS/lua-language-server/actions/runs/7967876039/job/21751273480). Therefore, moving build steps into independent docker environment is the easiest way to build with old GLIBC version, and not affecting the GitHub Workflow.