### PR TITLE
add: workflow to assert changelog updates

### DIFF
--- a/.github/scripts/check-changelog.sh
+++ b/.github/scripts/check-changelog.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+CHANGELOG_FILE="changelog.md"
+
+git fetch
+
+# Check if the changelog file was modified in the PR
+if git diff --name-only origin/$GITHUB_BASE_REF..$GITHUB_HEAD_REF | grep -q $CHANGELOG_FILE; then
+  echo "Thank you for updating the changelog!"
+  exit 0
+else
+  echo "Changelog has not been updated. Please update $CHANGELOG_FILE!"
+  exit 1
+fi

--- a/.github/scripts/check-changelog.sh
+++ b/.github/scripts/check-changelog.sh
@@ -8,8 +8,7 @@ CHANGELOG_FILE="changelog.md"
 git fetch origin $GITHUB_BASE_REF
 git fetch
 
-echo $(git remote)
-echo $(git branch)
+echo $(git branch -a)
 
 # Check if the changelog file was modified in the PR
 if git diff --name-only origin/$GITHUB_BASE_REF..$GITHUB_HEAD_REF | grep -q $CHANGELOG_FILE; then

--- a/.github/scripts/check-changelog.sh
+++ b/.github/scripts/check-changelog.sh
@@ -4,7 +4,7 @@ set -e
 
 CHANGELOG_FILE="changelog.md"
 
-git fetch
+git fetch origin $GITHUB_BASE_REF
 
 # Check if the changelog file was modified in the PR
 if git diff --name-only origin/$GITHUB_BASE_REF..$GITHUB_HEAD_REF | grep -q $CHANGELOG_FILE; then

--- a/.github/scripts/check-changelog.sh
+++ b/.github/scripts/check-changelog.sh
@@ -5,6 +5,7 @@ set -e
 CHANGELOG_FILE="changelog.md"
 
 git fetch origin $GITHUB_BASE_REF
+git fetch
 
 # Check if the changelog file was modified in the PR
 if git diff --name-only origin/$GITHUB_BASE_REF..$GITHUB_HEAD_REF | grep -q $CHANGELOG_FILE; then

--- a/.github/scripts/check-changelog.sh
+++ b/.github/scripts/check-changelog.sh
@@ -6,7 +6,7 @@ CHANGELOG_FILE="changelog.md"
 
 
 git fetch origin $GITHUB_BASE_REF
-git fetch --unshallow
+git fetch
 
 echo $(git remote)
 echo $(git branch)

--- a/.github/scripts/check-changelog.sh
+++ b/.github/scripts/check-changelog.sh
@@ -11,7 +11,7 @@ git fetch
 echo $(git branch -a)
 
 # Check if the changelog file was modified in the PR
-if git diff --name-only origin/$GITHUB_BASE_REF..$GITHUB_SOURCE_REF | grep -q $CHANGELOG_FILE; then
+if git diff --name-only origin/$GITHUB_BASE_REF..remotes/pull/$GITHUB_SOURCE_REF | grep -q $CHANGELOG_FILE; then
   echo "Thank you for updating the changelog!"
   exit 0
 else

--- a/.github/scripts/check-changelog.sh
+++ b/.github/scripts/check-changelog.sh
@@ -4,11 +4,8 @@ set -e
 
 CHANGELOG_FILE="changelog.md"
 
-
 git fetch origin $GITHUB_BASE_REF
 git fetch
-
-echo $(git branch -a)
 
 # Check if the changelog file was modified in the PR
 if git diff --name-only origin/$GITHUB_BASE_REF..remotes/pull/$GITHUB_SOURCE_REF | grep -q $CHANGELOG_FILE; then

--- a/.github/scripts/check-changelog.sh
+++ b/.github/scripts/check-changelog.sh
@@ -4,8 +4,12 @@ set -e
 
 CHANGELOG_FILE="changelog.md"
 
+
 git fetch origin $GITHUB_BASE_REF
-git fetch
+git fetch --unshallow
+
+echo $(git remote)
+echo $(git branch)
 
 # Check if the changelog file was modified in the PR
 if git diff --name-only origin/$GITHUB_BASE_REF..$GITHUB_HEAD_REF | grep -q $CHANGELOG_FILE; then

--- a/.github/scripts/check-changelog.sh
+++ b/.github/scripts/check-changelog.sh
@@ -11,7 +11,7 @@ git fetch
 echo $(git branch -a)
 
 # Check if the changelog file was modified in the PR
-if git diff --name-only origin/$GITHUB_BASE_REF..$GITHUB_HEAD_REF | grep -q $CHANGELOG_FILE; then
+if git diff --name-only origin/$GITHUB_BASE_REF..$GITHUB_SOURCE_REF | grep -q $CHANGELOG_FILE; then
   echo "Thank you for updating the changelog!"
   exit 0
 else

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -13,11 +13,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
         with:
-          fetch-depth: 2
+          fetch-depth: 0
 
       - name: Set up environment
         run: |
-          echo "GITHUB_HEAD_REF=${{ github.head_ref }}" >> $GITHUB_ENV
+          echo "GITHUB_HEAD_REF=${{ github.head_ref || github.ref_name }}" >> $GITHUB_ENV
           echo "GITHUB_BASE_REF=${{ github.base_ref }}" >> $GITHUB_ENV
 
       - name: Check if changelog is updated

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Set up environment
         run: |
-          echo "GITHUB_HEAD_REF=${{ github.head_ref || github.ref_name }}" >> $GITHUB_ENV
+          echo "GITHUB_SOURCE_REF=${{ github.ref_name }}" >> $GITHUB_ENV
           echo "GITHUB_BASE_REF=${{ github.base_ref }}" >> $GITHUB_ENV
 
       - name: Check if changelog is updated

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,24 @@
+name: changelog
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    branches:
+      - master
+
+jobs:
+  check-changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # Need entire git history
+
+      - name: Set up environment
+        run: |
+          echo "GITHUB_HEAD_REF=${{ github.head_ref }}" >> $GITHUB_ENV
+          echo "GITHUB_BASE_REF=${{ github.base_ref }}" >> $GITHUB_ENV
+
+      - name: Check if changelog is updated
+        run: .github/scripts/check-changelog.sh

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
         with:
-          fetch-depth: 0 # Need entire git history
+          fetch-depth: 2
 
       - name: Set up environment
         run: |

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # changelog
 
+## Unreleased
+<!-- Add all new changes here. They will be moved under a version at release -->
+
 ## 3.9.0
 `2024-5-11`
 * `NEW` goto implementation
@@ -123,7 +126,7 @@
     Cat = 1,
     Dog = 2,
   }
-  
+
   ---@param animal userdata
   ---@param atp AnimalType
   ---@return boolean


### PR DESCRIPTION
This PR adds a workflow that checks incoming PRs for changelog changes, failing if no changes were made.

Another important change is that the [changelog should always contain an “Unreleased” section](https://keepachangelog.com/en/1.1.0/#effort) at the top, so it is easy to add all new changes there between releases. When it is time for a new release, the points from under “Unreleased” are simply moved under a version number.

This should help prevent new changes from going under the radar.

@sumneko **I have also edited the branch protection rules on `master`** so that in order for a pull request to be merged, this changelog edit check **must** succeed before merging, although admins can still override it and merge regardless.