### PR TITLE
Throttle calls to await.delay() in some diagnostics

### DIFF
--- a/script/await.lua
+++ b/script/await.lua
@@ -176,6 +176,28 @@ function m.delay()
     return coroutine.yield()
 end
 
+local throttledDelayer = {}
+throttledDelayer.__index = throttledDelayer
+
+---@async
+function throttledDelayer:delay()
+    if not m._enable then
+        return
+    end
+    self.calls = self.calls + 1
+    if self.calls == self.factor then
+        self.calls = 0
+        return m.delay()
+    end
+end
+
+function m.newThrottledDelayer(factor)
+    return setmetatable({
+        factor = factor,
+        calls = 0,
+    }, throttledDelayer)
+end
+
 --- stop then close
 ---@async
 function m.stop()

--- a/script/core/diagnostics/assign-type-mismatch.lua
+++ b/script/core/diagnostics/assign-type-mismatch.lua
@@ -52,13 +52,14 @@ return function (uri, callback)
         return
     end
 
+    local delayer = await.newThrottledDelayer(15)
     ---@async
     guide.eachSourceTypes(state.ast, checkTypes, function (source)
         local value = source.value
         if not value then
             return
         end
-        await.delay()
+        delayer:delay()
         if source.type == 'setlocal' then
             local locNode = vm.compileNode(source.node)
             if not locNode.hasDefined then

--- a/script/core/diagnostics/need-check-nil.lua
+++ b/script/core/diagnostics/need-check-nil.lua
@@ -11,9 +11,10 @@ return function (uri, callback)
         return
     end
 
+    local delayer = await.newThrottledDelayer(500)
     ---@async
     guide.eachSourceType(state.ast, 'getlocal', function (src)
-        await.delay()
+        delayer:delay()
         local checkNil
         local nxt = src.next
         if nxt then

--- a/script/core/diagnostics/redundant-value.lua
+++ b/script/core/diagnostics/redundant-value.lua
@@ -11,8 +11,9 @@ return function (uri, callback)
         return
     end
 
+    local delayer = await.newThrottledDelayer(50000)
     guide.eachSource(state.ast, function (src) ---@async
-        await.delay()
+        delayer:delay()
         if src.redundant then
             callback {
                 start   = src.start,

--- a/script/core/diagnostics/trailing-space.lua
+++ b/script/core/diagnostics/trailing-space.lua
@@ -10,9 +10,10 @@ return function (uri, callback)
     if not state or not text then
         return
     end
+    local delayer = await.newThrottledDelayer(5000)
     local lines = state.lines
     for i = 0, #lines do
-        await.delay()
+        delayer:delay()
         local startOffset  = lines[i]
         local finishOffset = text:find('[\r\n]', startOffset) or (#text + 1)
         local lastOffset   = finishOffset - 1

--- a/script/core/diagnostics/unbalanced-assignments.lua
+++ b/script/core/diagnostics/unbalanced-assignments.lua
@@ -41,9 +41,10 @@ return function (uri, callback, code)
         end
     end
 
+    local delayer = await.newThrottledDelayer(1000)
     ---@async
     guide.eachSourceTypes(ast.ast, types, function (source)
-        await.delay()
+        delayer:delay()
         checkSet(source)
     end)
 end


### PR DESCRIPTION
These 5 diagnostics cause ~70% of all calls to await.delay() by diagnostics which in turn is about ~20% of the total runtime of diagnostics.

Out of these diagnostics only assign-type-mismatch commonly exceeds runtimes of 100ms (worst observed in my dataset was 7 seconds) and even then it still attempts to call await.delay() over 1500 times per second, so throttling by a factor of 15 is still fine.


There are likely more places where await() could be optimized, but the diagnostics are the low-hanging fruit because they are easy to find.