### PR TITLE
don't do diagnostics when workspace is not ready

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 <!-- Add all new changes here. They will be moved under a version at release -->
+* `FIX` Don't do diagnostics when the workspace is not ready
 * `NEW` Reference workspace symbols in comments using `[some text](lua://symbolName)` syntax
 
 ## 3.9.0

--- a/script/provider/diagnostic.lua
+++ b/script/provider/diagnostic.lua
@@ -246,6 +246,9 @@ local function isValid(uri)
     if not config.get(uri, 'Lua.diagnostics.enable') then
         return false
     end
+    if not ws.isReady(uri) then
+        return false
+    end
     if files.isLibrary(uri, true) then
         local status = config.get(uri, 'Lua.diagnostics.libraryFiles')
         if status == 'Disable' then


### PR DESCRIPTION
Hi!

I created a new Neovim [plugin](https://github.com/folke/lazydev.nvim) that automatically updates the `workspace/library` configuration for the active workspace folder based on what files the user has open in Neovim.

It works great and is a lot faster than my older `neodev.nvim` plugin.

However, one thing I noticed, is that when I send a `workspace/didChangeConfiguration`, the diagnostics of the currently open files, become all wrong (things like, `string`, or `table` does not exist).
After a couple of seconds, they are then replaced by the correct diagnostics.

After debugging, it seems that diagnostics sometimes run, even when the workspace is not ready.

This PR fixes that.
