### PR TITLE
Fix plugin arg arrays when paths contain numbers passing along only one argument

### DIFF
--- a/script/plugin.lua
+++ b/script/plugin.lua
@@ -156,7 +156,7 @@ local function initPlugin(uri)
         end
         for i, pluginConfigPath in ipairs(pluginConfigPaths) do
             local myArgs = args
-            if args then
+            if args and not args[1] then
                 for k, v in pairs(args) do
                     if pluginConfigPath:find(k, 1, true) then
                         myArgs = v


### PR DESCRIPTION
Specifically to prevent it from trying to match the tostring-ed numeric number keys of plain arrays with config folder paths, which can lead to false positives if those paths contain numbers and then ultimately results in only a single argument out of the arguments array being passed along

Side note, it's nice for multi plugin to be natively supported, plus separating plugin args like this. Though this is a bug where the plugin args are just an array without any separating which is only useful when there's a single plugin so I suppose it's unrelated but still thank you :D