### PR TITLE
Add postfix snippet for `unpack`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 <!-- Add all new changes here. They will be moved under a version at release -->
+* `NEW` Add postfix snippet for `unpack`
 
 ## 3.9.3
 `2024-6-11`

--- a/script/core/completion/postfix.lua
+++ b/script/core/completion/postfix.lua
@@ -220,6 +220,24 @@ register 'pairs' {
     end
 }
 
+register 'unpack' {
+    function (state, source, callback)
+        if  source.type ~= 'getglobal'
+        and source.type ~= 'getfield'
+        and source.type ~= 'getmethod'
+        and source.type ~= 'getindex'
+        and source.type ~= 'getlocal'
+        and source.type ~= 'call'
+        and source.type ~= 'table' then
+            return
+        end
+        local subber = subString(state)
+        callback(string.format('unpack(%s)'
+            , subber(source.start + 1, source.finish)
+        ))
+    end
+}
+
 register 'insert' {
     function (state, source, callback)
         if  source.type ~= 'getglobal'


### PR DESCRIPTION
Sometimes we are not sure whether functions return a tuple or a table, assuming we need to get a position containing `row` and `col`, wrote:
```lua
local position = get_position()
```
Then we found `position` here is an `integer`, not a `table` (by inlay hint or diagnostic info), which means `get position` returns a tuple. In this situation, a postfix snippet will be useful because our cursor is at the end of the line. By simply typing `@unpack` we can turn it into a tuple.
```lua
local position = unpack(get_position())
```
That's why I think this snippet is useful.