### PR TITLE
Add support for lambda-style functions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # changelog
 
 ## Unreleased
+<!-- Add all new changes here. They will be moved under a version at release -->
 `2024-6-19`
 * `NEW` Add support for lambda style functions, `|paramList| expr` is syntactic sugar for `function(paramList) return expr end` 
 

--- a/changelog.md
+++ b/changelog.md
@@ -3,7 +3,6 @@
 ## Unreleased
 <!-- Add all new changes here. They will be moved under a version at release -->
 * `NEW` Add postfix snippet for `unpack`
-`2024-6-19`
 * `NEW` Add support for lambda style functions, `|paramList| expr` is syntactic sugar for `function(paramList) return expr end` 
 
 ## 3.9.3

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,8 @@
 # changelog
 
 ## Unreleased
-<!-- Add all new changes here. They will be moved under a version at release -->
+`2024-6-19`
+* `NEW` Add support for lambda style functions, `|paramList| expr` is syntactic sugar for `function(paramList) return expr end` 
 
 ## 3.9.3
 `2024-6-11`

--- a/doc/en-us/config.md
+++ b/doc/en-us/config.md
@@ -1829,6 +1829,7 @@ Array<string>
 * ``"!"``
 * ``"!="``
 * ``"continue"``
+* ``"|lambda|"``
 
 ## default
 

--- a/doc/pt-br/config.md
+++ b/doc/pt-br/config.md
@@ -1829,6 +1829,7 @@ Array<string>
 * ``"!"``
 * ``"!="``
 * ``"continue"``
+* ``"|lambda|"``
 
 ## default
 


### PR DESCRIPTION
I've implemented support for lambda-style functions. Currently, this is configured by adding `|lambda|` to `Runtime.nonstandardSymbols`. It's trivial to change it to be exposed to the user with a different option, if necessary.

Closes #2515