### PR TITLE
fix: default severity in CLI with partial 'diagnostics.severity' config

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ## Unreleased
 <!-- Add all new changes here. They will be moved under a version at release -->
 * `NEW` Add postfix snippet for `unpack`
+* `FIX` `diagnostics.severity` defaulting to "Warning" when run using `--check` [#2730](https://github.com/LuaLS/lua-language-server/issues/2730)
 
 ## 3.9.3
 `2024-6-11`

--- a/script/cli/check_worker.lua
+++ b/script/cli/check_worker.lua
@@ -83,7 +83,7 @@ xpcall(lclient.start, errorhandler, lclient, function (client)
 
     local disables = util.arrayToHash(config.get(rootUri, 'Lua.diagnostics.disable'))
     for name, serverity in pairs(define.DiagnosticDefaultSeverity) do
-        serverity = config.get(rootUri, 'Lua.diagnostics.severity')[name] or 'Warning'
+        serverity = config.get(rootUri, 'Lua.diagnostics.severity')[name] or serverity
         if serverity:sub(-1) == '!' then
             serverity = serverity:sub(1, -2)
         end


### PR DESCRIPTION
The default severity when running CLI `--check` is incorrectly set to `'Warning'` if the `diagnostics.severity` config table is incomplete.

This will fix #2730  .