### PR TITLE
fix: respect showParams config for local function completion

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 * `NEW` Add postfix snippet for `unpack`
 * `FIX` `diagnostics.severity` defaulting to "Warning" when run using `--check` [#2730](https://github.com/LuaLS/lua-language-server/issues/2730)
 * `NEW` Add support for lambda style functions, `|paramList| expr` is syntactic sugar for `function(paramList) return expr end` 
+* `FIX` Respect `completion.showParams` config for local function completion 
 
 ## 3.9.3
 `2024-6-11`

--- a/script/core/completion/completion.lua
+++ b/script/core/completion/completion.lua
@@ -343,6 +343,7 @@ end
 
 local function checkLocal(state, word, position, results)
     local locals = guide.getVisibleLocals(state.ast, position)
+    local showParams = config.get(state.uri, 'Lua.completion.showParams')
     for name, source in util.sortPairs(locals) do
         if isSameSource(state, source, position) then
             goto CONTINUE
@@ -372,7 +373,12 @@ local function checkLocal(state, word, position, results)
             for _, def in ipairs(defs) do
                 if (def.type == 'function' and not vm.isVarargFunctionWithOverloads(def))
                 or def.type == 'doc.type.function' then
-                    local funcLabel = name .. getParams(def, false)
+                    local funcLabel
+                    if showParams then
+                        funcLabel = name .. getParams(def, false)
+                    else
+                        funcLabel = name
+                    end
                     buildFunction(results, source, def, false, {
                         label      = funcLabel,
                         match      = name,


### PR DESCRIPTION
This PR fixes the issue that the `showParams` config is not respected when completing local functions. I've attached screenshots to illustrate this problem (with `completion.showParams` set to false)

Before this fix:

![Screenshot_2024-06-28_14-49-41](https://github.com/LuaLS/lua-language-server/assets/23468812/72d89720-740d-4411-aed5-ef2d5828338e)

After this fix:

![Screenshot_2024-06-28_17-53-27](https://github.com/LuaLS/lua-language-server/assets/23468812/a696a328-0e73-4394-9a32-c2097d7f7220)
