### PR TITLE
Perf: Improve performance of multithreaded `--check` and `undefined-field` diagnostic

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 * `NEW` Add postfix snippet for `unpack`
 * `FIX` `diagnostics.severity` defaulting to "Warning" when run using `--check` [#2730](https://github.com/LuaLS/lua-language-server/issues/2730)
 * `NEW` Add support for lambda style functions, `|paramList| expr` is syntactic sugar for `function(paramList) return expr end` 
+* `CHG` Improve performance of multithreaded `--check` and `undefined-field` diagnostic
 
 ## 3.9.3
 `2024-6-11`

--- a/script/cli/check_worker.lua
+++ b/script/cli/check_worker.lua
@@ -43,15 +43,6 @@ local checkLevel = define.DiagnosticSeverity[CHECKLEVEL] or define.DiagnosticSev
 
 util.enableCloseFunction()
 
--- Hash function used to distribute work.
-local function hashString(str)
-    local hash = 0
-    for i = 1, #str do
-        hash = (hash * 37 & 0xFFFFFFFF) + str:byte(i, i)
-    end
-    return hash
-end
-
 local lastClock = os.clock()
 local results = {}
 
@@ -109,9 +100,9 @@ xpcall(lclient.start, errorhandler, lclient, function (client)
 
     local uris = files.getChildFiles(rootUri)
     local max  = #uris
+    table.sort(uris)    -- sort file list to ensure the work distribution order across multiple threads
     for i, uri in ipairs(uris) do
-        local hash = hashString(uri) % numThreads + 1
-        if hash == threadId then
+        if (i % numThreads + 1) == threadId then
             files.open(uri)
             diag.doDiagnostic(uri, true)
             -- Print regularly but always print the last entry to ensure that logs written to files don't look incomplete.

--- a/script/core/diagnostics/undefined-field.lua
+++ b/script/core/diagnostics/undefined-field.lua
@@ -21,7 +21,7 @@ return function (uri, callback)
     local function checkUndefinedField(src)
         await.delay()
 
-        if #vm.getDefs(src) > 0 then
+        if vm.hasDef(src) then
             return
         end
         local node = src.node


### PR DESCRIPTION
Recently I am integrating LuaLs into our project's CI and I am looking for ways to speed up the process. The following are 2 simple optimizations that I have found:

## Work distribution in multi-threaded `--check`
I found this recently added **multi-threaded `--check`** in #2638. Upon some code reviewing I suspect that the hash function used to distribute work across multi threads is not that perfect, which limits its full potential. I simply changed it to **Round Robin** (after sorting the file list of course), and this yields another **`10%`** performance gain in my project workspace (500+ lua files). Benchmarks as follow:

- CPU: Intel(R) Core(TM) i7-4790 CPU @ 3.60GHz

| threads | ori-1 | ori-2 | ori-3 | ori-avg  |   | new-1 | new-2 | new-3 | new-avg  |   | diff |
|---------|-------|-------|-------|----------|---|-------|-------|-------|----------|---|------|
| 1       | 38.67 | 38.88 | 38.76 | 38.77    |   | 38.77 | 39.35 | 38.75 | 38.95667 |   | 0%   |
| 2       | 25.57 | 25.64 | 25.79 | 25.66667 |   | 22.93 | 22.89 | 22.86 | 22.89333 |   | -11% |
| 4       | 17.55 | 17.93 | 17.41 | 17.63    |   | 15.81 | 15.22 | 15.33 | 15.45333 |   | -12% |

I would like to mention @emmericp here as this function is originally implemented by him, to see if this small optimization can help shaving off a few more seconds in his project 😄 (great work btw 👍 )

## Early break in `undefined-field` diagnostic
Upon some profiling, the `undefined-field` check is quite time consuming. By looking into the code I found the early break logic of it can be optimized. The `#vm.getDefs(src) > 0` is used to check if there is any definition for a given `src` object, and there is no need to fetch the full definitions list. We can actually return as soon as the 1st definition is found. This yields a **`25%`** performance gain in this single check within my workspace 🚀 

- setting `"diagnostics.severity": { "undefined-field": "Error!" }` in `.luarc.json` then run with `--checklevel=Error`
NOTE: The following is run in **single thread** to avoid confusion with the above threaded optimization.

|      | 1     | 2     | 3     | avg      |
|------|-------|-------|-------|----------|
| ori  | 15.4  | 15.39 | 15.44 | 15.41    |
| new  | 11.51 | 11.26 | 11.26 | 11.34333 |
| diff |       |       |       | -26%     |