### PR TITLE
Align inlay hint spacing with other LSPs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@
 * `NEW` Add support for lambda style functions, `|paramList| expr` is syntactic sugar for `function(paramList) return expr end` 
 * `FIX` Respect `completion.showParams` config for local function completion 
 * `CHG` Improve performance of multithreaded `--check` and `undefined-field` diagnostic
+* `CHG` Change spacing of parameter inlay hints to match other LSPs, like `rust-analyzer`
 
 ## 3.9.3
 `2024-6-11`

--- a/script/core/hint.lua
+++ b/script/core/hint.lua
@@ -59,7 +59,7 @@ local function typeHint(uri, results, start, finish)
         end
         mark[src] = true
         results[#results+1] = {
-            text   = ':' .. view,
+            text   = ': ' .. view,
             offset = src.finish,
             kind   = define.InlayHintKind.Type,
             where  = 'right',

--- a/script/provider/provider.lua
+++ b/script/provider/provider.lua
@@ -1426,8 +1426,8 @@ m.register 'textDocument/inlayHint' {
                 },
                 position     = converter.packPosition(state, res.offset),
                 kind         = res.kind,
-                paddingLeft  = res.kind == 1,
-                paddingRight = res.kind == 2,
+                paddingLeft  = false,
+                paddingRight = res.kind == define.InlayHintKind.Parameter,
             }
         end
         return hintResults


### PR DESCRIPTION
Basically a cosmetic change. Aligns the parameter inlay hint spacing with that of most other LSPs that I've seen
Before:
![beforeinlayhint](https://github.com/LuaLS/lua-language-server/assets/55766287/d11c6f99-2d5f-459d-adb0-87b23f7f2e99)
After:
![after_inlay_hint](https://github.com/LuaLS/lua-language-server/assets/55766287/1b1b5c1e-6d1d-4445-af0c-71d6ad7a96f7)
