### PR TITLE
Remove nodiscard from string.gsub

### DIFF
--- a/meta/template/string.lua
+++ b/meta/template/string.lua
@@ -73,7 +73,6 @@ function string.gmatch(s, pattern, init) end
 ---@param n?      integer
 ---@return string
 ---@return integer count
----@nodiscard
 function string.gsub(s, pattern, repl, n) end
 
 ---#DES 'string.len'


### PR DESCRIPTION
常用的写法，第二个参数是函数时，可以不需要关心返回值。因为它的结果已经通过函数的upvalue向外传递。

``` lua
local function split(str)
    local r = {}
    str:gsub("[^\n]+", function (w) r[#r+1] = w end)
    return r
end
```

@sumneko 如果能更智能一点，对第二个参数是函数情形去掉nodiscard，其余情况保留nodiscard。例如这样 

``` lua
---@param s       string|number
---@param pattern string|number
---@param repl    string|number|table
---@param n?      integer
---@return string
---@return integer count
---@nodiscard
function string.gsub(s, pattern, repl, n) end

---@param s       string|number
---@param pattern string|number
---@param repl    function
---@param n?      integer
---@return string
---@return integer count
function string.gsub(s, pattern, repl, n) end
```
