### PR TITLE
added lua regular expression support for Lua.doc.<scope>Name

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,8 @@
 * `NEW` Add support for lambda style functions, `|paramList| expr` is syntactic sugar for `function(paramList) return expr end` 
 * `FIX` Respect `completion.showParams` config for local function completion 
 * `CHG` Improve performance of multithreaded `--check` and `undefined-field` diagnostic
+* `NEW` added lua regular expression support for Lua.doc.<scope>Name [#2753](https://github.com/LuaLS/lua-language-server/pull/2753)
+
 
 ## 3.9.3
 `2024-6-11`

--- a/script/config/template.lua
+++ b/script/config/template.lua
@@ -402,7 +402,10 @@ local template = {
     ['Lua.doc.privateName']                 = Type.Array(Type.String),
     ['Lua.doc.protectedName']               = Type.Array(Type.String),
     ['Lua.doc.packageName']                 = Type.Array(Type.String),
-
+    ['Lua.doc.regengine']                   = Type.String >> 'glob' << {
+                                                'glob',
+                                                'lua',
+                                            },
     -- VSCode
     ["Lua.addonManager.enable"]             = Type.Boolean >> true,
     ['files.associations']                  = Type.Hash(Type.String, Type.String),

--- a/script/vm/visible.lua
+++ b/script/vm/visible.lua
@@ -42,21 +42,33 @@ local function getVisibleType(source)
 
     if type(fieldName) == 'string' then
         local uri = guide.getUri(source)
+        local regengine = config.get(uri, 'Lua.doc.regengine')
+        local function match(patterns)
+            if regengine == "glob" then
+               return glob.glob(patterns)(fieldName)
+            else
+                for i = 1, #patterns do
+                    if string.find(fieldName, patterns[i]) then
+                        return true
+                    end
+                end
+            end
+        end
 
         local privateNames = config.get(uri, 'Lua.doc.privateName')
-        if #privateNames > 0 and glob.glob(privateNames)(fieldName) then
+        if #privateNames > 0 and match(privateNames) then
             source._visibleType = 'private'
             return 'private'
         end
-
+        
         local protectedNames = config.get(uri, 'Lua.doc.protectedName')
-        if #protectedNames > 0 and glob.glob(protectedNames)(fieldName) then
+        if #protectedNames > 0 and match(protectedNames) then
             source._visibleType = 'protected'
             return 'protected'
         end
-
+        
         local packageNames = config.get(uri, 'Lua.doc.packageName')
-        if #packageNames > 0 and glob.glob(packageNames)(fieldName) then
+        if #packageNames > 0 and match(packageNames) then
             source._visibleType = 'package'
             return 'package'
         end

--- a/test/diagnostics/invisible.lua
+++ b/test/diagnostics/invisible.lua
@@ -104,6 +104,28 @@ print(t2._id)
 ]]
 config.set(nil, 'Lua.doc.protectedName', nil)
 
+config.set(nil, 'Lua.doc.regengine', 'lua' )
+config.set(nil, 'Lua.doc.privateName', { '^_[%w_]*%w$' })
+config.set(nil, 'Lua.doc.protectedName', { '^_[%w_]*_$' })
+TEST [[
+---@class A
+---@field _id_ number
+---@field _user number
+
+---@type A
+local t
+print(t.<!_id_!>)
+print(t.<!_user!>)
+
+---@class B: A
+local t2
+print(t2._id_)
+print(t2.<!_user!>)
+]]
+config.set(nil, 'Lua.doc.privateName', nil)
+config.set(nil, 'Lua.doc.protectedName', nil)
+config.set(nil, 'Lua.doc.regengine', nil )
+
 TEST [[
 ---@class A
 ---@field private x number


### PR DESCRIPTION
hi,
this PR add support for lua regular expressions for parameters:
- `Lua.doc.privateName`
- `Lua.doc.packageName`
- `Lua.doc.protectedName`

it also adds a new `Lua.doc.regengine` (the name can be changed) parameter, which can be set to `glob(default)` or `lua`

```json
{
  "Lua.doc.protectedName": [
	  "^_[%w_]*_$"
  ],
  "Lua.doc.privateName": [
	  "^_[%w_]*%w$"
  ],
  "Lua.doc.regengine": "lua",
}
```
```lua

---@class A
local A = {}
A._id_ = 0 --  is protected
A._user = "bob" -- is private

---@type A
local t
print(t._id_) -- warning
print(t._user) -- warning

---@class B: A
local t2
print(t2._id_) 
print(t2._user) -- warning
```