### PR TITLE
Fixed wholeMatch function

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,9 +4,10 @@
 <!-- Add all new changes here. They will be moved under a version at release -->
 * `NEW` Add postfix snippet for `unpack`
 * `FIX` `diagnostics.severity` defaulting to "Warning" when run using `--check` [#2730](https://github.com/LuaLS/lua-language-server/issues/2730)
-* `NEW` Add support for lambda style functions, `|paramList| expr` is syntactic sugar for `function(paramList) return expr end` 
-* `FIX` Respect `completion.showParams` config for local function completion 
+* `NEW` Add support for lambda style functions, `|paramList| expr` is syntactic sugar for `function(paramList) return expr end`
+* `FIX` Respect `completion.showParams` config for local function completion
 * `CHG` Improve performance of multithreaded `--check` and `undefined-field` diagnostic
+* `FIX` Addons can now self-recommend as expected. Fixed by correcting the `wholeMatch` function
 
 ## 3.9.3
 `2024-6-11`
@@ -145,7 +146,7 @@
     Cat = 1,
     Dog = 2,
   }
-  
+
   ---@param animal userdata
   ---@param atp AnimalType
   ---@return boolean

--- a/script/library.lua
+++ b/script/library.lua
@@ -360,7 +360,7 @@ local function loadSingle3rdConfig(libraryDir)
 
     if cfg.words then
         for i, word in ipairs(cfg.words) do
-            cfg.words[i] = '()' .. word .. '()'
+            cfg.words[i] = '([%w_]?)' .. word .. '([%w_]?)'
         end
     end
     if cfg.files then
@@ -370,7 +370,7 @@ local function loadSingle3rdConfig(libraryDir)
             else
                 filename = filename:gsub('\\', '/')
             end
-            cfg.files[i] = '()' .. filename .. '()'
+            cfg.files[i] = '([%w_]?)' .. filename .. '([%w_]?)'
         end
     end
 
@@ -515,17 +515,10 @@ end
 ---@param b string
 ---@return boolean
 local function wholeMatch(a, b)
-    local pos1, pos2 = a:match(b)
-    if not pos1 then
-        return false
-    end
-    local left  = a:sub(pos1 - 1, pos1 - 1)
-    local right = a:sub(pos2, pos2)
-    if left:match '[%w_]'
-    or right:match '[%w_]' then
-        return false
-    end
-    return true
+    local captures = {
+        a:match(b),
+    }
+    return captures[1] == '' and captures[#captures] == ''
 end
 
 local function check3rdByWords(uri, configs, checkThirdParty)


### PR DESCRIPTION
# What did the PR do
The PR corrects the `wholeMatch` function, making it work effectively and more efficiently. The addon can self-recommendation as expected now.
# Why do so
The doc recommends writing `words` in `config.json` like this:
```json
"words": [ "require[%s%(\"']+MAA[%)\"']" ]
```
Most addon authors captured the require string in the doc. However, a commit three years ago (`f4e4cc0114adba8d199f9f81298a7c15c9576d5c`) modified the code from:
```lua
if text:match(word) then
...
```
to
```lua
local pos1, pos2 = a:match('()' .. word .. '()')
local left = a:sub(pos1 - 1, pos1-1)
local right = a:sub(pos2, pos2)
...
```
Unfortunately, if the pattern word itself has captures (similar to the doc example), `pos2` will return a string instead of a number. Consequently, the whole self-recommend feature hasn't worked for the past three years.