### PR TITLE
fix: inconsistent type narrow due to outdated node caches of call.args

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@
 * `NEW` added lua regular expression support for Lua.doc.<scope>Name [#2753](https://github.com/LuaLS/lua-language-server/pull/2753)
 * `FIX` Bad triggering of the `inject-field` diagnostic, when the fields are declared at the creation of the object [#2746](https://github.com/LuaLS/lua-language-server/issues/2746)
 * `CHG` Change spacing of parameter inlay hints to match other LSPs, like `rust-analyzer`
+* `FIX` Inconsistent type narrow behavior of function call args [#2758](https://github.com/LuaLS/lua-language-server/issues/2758)
 
 ## 3.9.3
 `2024-6-11`

--- a/script/vm/compiler.lua
+++ b/script/vm/compiler.lua
@@ -575,6 +575,12 @@ local function matchCall(source)
         newNode:removeNode(needRemove)
         newNode.originNode = myNode
         vm.setNode(source, newNode, true)
+        if call.args then
+            -- clear node caches of args to allow recomputation with the type narrowed call
+            for _, arg in ipairs(call.args) do
+                vm.removeNode(arg)
+            end
+        end
     end
 end
 


### PR DESCRIPTION
this will fix #2758 

bug explanation in this comment: https://github.com/LuaLS/lua-language-server/issues/2758#issuecomment-2232618218