### PR TITLE
feat: flip binary operator check if failed (#2777)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 <!-- Add all new changes here. They will be moved under a version at release -->
+* `NEW` Add support for binary metamethod on right operand [#2777](https://github.com/LuaLS/lua-language-server/pull/2777)
 
 ## 3.10.1
 `2024-8-2`

--- a/script/vm/operator.lua
+++ b/script/vm/operator.lua
@@ -261,6 +261,9 @@ vm.binarySwitch = util.switch()
             })
         else
             local node = vm.runOperator(binaryMap[op], source[1], source[2])
+            if not node then
+                node = vm.runOperator(binaryMap[op], source[2], source[1])
+            end
             if node then
                 vm.setNode(source, node)
             end
@@ -300,6 +303,9 @@ vm.binarySwitch = util.switch()
             })
         else
             local node = vm.runOperator(binaryMap[op], source[1], source[2])
+            if not node then
+                node = vm.runOperator(binaryMap[op], source[2], source[1])
+            end
             if node then
                 vm.setNode(source, node)
                 return
@@ -396,6 +402,9 @@ vm.binarySwitch = util.switch()
                 return
             end
             local node = vm.runOperator(binaryMap[source.op.type], source[1], source[2])
+            if not node then
+                node = vm.runOperator(binaryMap[source.op.type], source[2], source[1])
+            end
             if node then
                 vm.setNode(source, node)
             end

--- a/test/type_inference/common.lua
+++ b/test/type_inference/common.lua
@@ -4192,3 +4192,239 @@ TEST 'boolean|number' [[
 ---@type A
 local <?x?>
 ]]
+
+--reverse binary operator tests
+
+TEST 'A' [[
+---@class A
+---@operator add(number): A
+
+---@type A
+local x
+local <?y?> = x + 1
+]]
+
+TEST 'A' [[
+---@class A
+---@operator add(number): A
+
+---@type A
+local x
+local <?y?> = 1 + x
+]]
+
+TEST 'A' [[
+---@class A
+---@operator sub(number): A
+
+---@type A
+local x
+local <?y?> = x - 1
+]]
+
+TEST 'A' [[
+---@class A
+---@operator sub(number): A
+
+---@type A
+local x
+local <?y?> = 1 - x
+]]
+
+TEST 'A' [[
+---@class A
+---@operator mul(number): A
+
+---@type A
+local x
+local <?y?> = x * 1
+]]
+
+TEST 'A' [[
+---@class A
+---@operator mul(number): A
+
+---@type A
+local x
+local <?y?> = 1 * x
+]]
+
+TEST 'A' [[
+---@class A
+---@operator div(number): A
+
+---@type A
+local x
+local <?y?> = x / 1
+]]
+
+TEST 'A' [[
+---@class A
+---@operator div(number): A
+
+---@type A
+local x
+local <?y?> = 1 / x
+]]
+
+TEST 'A' [[
+---@class A
+---@operator idiv(number): A
+
+---@type A
+local x
+local <?y?> = x // 1
+]]
+
+TEST 'A' [[
+---@class A
+---@operator idiv(number): A
+
+---@type A
+local x
+local <?y?> = 1 // x
+]]
+
+TEST 'A' [[
+---@class A
+---@operator mod(number): A
+
+---@type A
+local x
+local <?y?> = x % 1
+]]
+
+TEST 'A' [[
+---@class A
+---@operator mod(number): A
+
+---@type A
+local x
+local <?y?> = 1 % x
+]]
+
+TEST 'A' [[
+---@class A
+---@operator pow(number): A
+
+---@type A
+local x
+local <?y?> = x ^ 1
+]]
+
+TEST 'A' [[
+---@class A
+---@operator pow(number): A
+
+---@type A
+local x
+local <?y?> = 1 ^ x
+]]
+
+TEST 'A' [[
+---@class A
+---@operator concat(number): A
+
+---@type A
+local x
+local <?y?> = x .. 1
+]]
+
+TEST 'A' [[
+---@class A
+---@operator concat(number): A
+
+---@type A
+local x
+local <?y?> = 1 .. x
+]]
+
+TEST 'A' [[
+---@class A
+---@operator band(number): A
+
+---@type A
+local x
+local <?y?> = x & 1
+]]
+
+TEST 'A' [[
+---@class A
+---@operator band(number): A
+
+---@type A
+local x
+local <?y?> = 1 & x
+]]
+
+TEST 'A' [[
+---@class A
+---@operator bor(number): A
+
+---@type A
+local x
+local <?y?> = x | 1
+]]
+
+TEST 'A' [[
+---@class A
+---@operator bor(number): A
+
+---@type A
+local x
+local <?y?> = 1 | x
+]]
+
+TEST 'A' [[
+---@class A
+---@operator bxor(number): A
+
+---@type A
+local x
+local <?y?> = x ~ 1
+]]
+
+TEST 'A' [[
+---@class A
+---@operator bxor(number): A
+
+---@type A
+local x
+local <?y?> = 1 ~ x
+]]
+
+TEST 'A' [[
+---@class A
+---@operator shl(number): A
+
+---@type A
+local x
+local <?y?> = x << 1
+]]
+
+TEST 'A' [[
+---@class A
+---@operator shl(number): A
+
+---@type A
+local x
+local <?y?> = 1 << x
+]]
+
+TEST 'A' [[
+---@class A
+---@operator shr(number): A
+
+---@type A
+local x
+local <?y?> = x >> 1
+]]
+
+TEST 'A' [[
+---@class A
+---@operator shr(number): A
+
+---@type A
+local x
+local <?y?> = 1 >> x
+]]


### PR DESCRIPTION
#2777 
if vm.runOperator fails try again with flipped arguments
this emulates how lua checks the binary metaevents in which
if there is no corresponding binary metaevent for the left
operand it checks the right operand instead. This also works
when both operands are tables.

example case:
```lua
---@class Vector3
---@operator add(number): Vector3
Vector3 = {}

---@type number
local x
local a = x + Vector3
-- type of a is now Vector3
```

This change affects:
- __add
- __sub
- __mul
- __div
- __idiv
- __mod
- __pow
- __concat
- __band
- __bor
- __bxor
- __shl
- __shr

Credit to tomlau10 for preliminary code