### PR TITLE
fix: improve textDocument/definition ordering

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 <!-- Add all new changes here. They will be moved under a version at release -->
+* `FIX` Improved ordering of results for `textDocument/definition`.
 
 ## 3.10.3
 `2024-8-8`

--- a/script/core/definition.lua
+++ b/script/core/definition.lua
@@ -51,6 +51,9 @@ end
 --- @param path2 string
 --- @return number
 local function pathSimilarityRatio(path1, path2)
+    if path1 == path2 then
+        return 0
+    end
     local parts1 = split(path1)
     local parts2 = split(path2)
     local distance = levenshteinDistance(parts1, parts2)


### PR DESCRIPTION
E.g. if the current document has path `c/file.lua` and the results have paths:

- `c/file.lua`
- `a/file.lua`

Prefer `c/file.lua` since that is most similar to the current document.

---

Real world example used these paths:

From `/Users/lewis/projects/neovim/runtime/lua/vim/lsp/handlers.lua` with results (in order):
- `/Users/lewis/.cache/lua-language-server/meta/LuaJIT en-us utf8/builtin.lua`
- `/Users/lewis/projects/neovim/runtime/lua/vim/lsp/handlers.lua`

