### PR TITLE
FIX: Changed hello param to valid JSONRPC

### DIFF
--- a/script/service/service.lua
+++ b/script/service/service.lua
@@ -250,7 +250,7 @@ function m.testVersion()
 end
 
 function m.sayHello()
-    proto.notify('$/hello', 'world')
+    proto.notify('$/hello', {'world'})
 end
 
 function m.lockCache()


### PR DESCRIPTION
The previous hello jsonrpc message caused sadness
since it caused lsp clients to exit as it was not
a correct way to say hello.

closes: #2797 