### PR TITLE
Fix setfenv definition

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 <!-- Add all new changes here. They will be moved under a version at release -->
 * `NEW` Custom documentation exporter
 * `NEW` Setting: `Lua.docScriptPath`: Path to a script that overrides `cli.doc.export`, allowing user-specified documentation exporting.
+* `FIX` Lua 5.1: fix incorrect warning when using setfenv with an int as first parameter
 
 ## 3.10.5
 `2024-8-19`

--- a/meta/template/basic.lua
+++ b/meta/template/basic.lua
@@ -210,7 +210,7 @@ function select(index, ...) end
 
 ---@version 5.1
 ---#DES 'setfenv'
----@param f     async fun(...):...|integer
+---@param f     (async fun(...):...)|integer
 ---@param table table
 ---@return function
 function setfenv(f, table) end


### PR DESCRIPTION
The first parameter got parsed as `async fun(...):(...|integer)` which triggered an incorrect warning when using it as `setfenv(2, env)`