### PR TITLE
Fix incorrect function params' type infer when there is only `@overload`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@
 * `FIX` Fix `VM.OnCompileFunctionParam` function in plugins
 * `FIX` Lua 5.1: fix incorrect warning when using setfenv with an int as first parameter
 * `FIX` Improve type narrow by checking exact match on literal type params
+* `FIX` Incorrect function params' type infer when there is only `@overload` [#2509](https://github.com/LuaLS/lua-language-server/issues/2509) [#2708](https://github.com/LuaLS/lua-language-server/issues/2708) [#2709](https://github.com/LuaLS/lua-language-server/issues/2709)
 
 ## 3.10.5
 `2024-8-19`

--- a/script/vm/compiler.lua
+++ b/script/vm/compiler.lua
@@ -1099,6 +1099,7 @@ local function compileFunctionParam(func, source)
 
     -- local call ---@type fun(f: fun(x: number));call(function (x) end) --> x -> number
     local funcNode = vm.compileNode(func)
+    local found = false
     for n in funcNode:eachObject() do
         if n.type == 'doc.type.function' and n.args[aindex] then
             local argNode = vm.compileNode(n.args[aindex])
@@ -1107,8 +1108,15 @@ local function compileFunctionParam(func, source)
                     vm.setNode(source, an)
                 end
             end
-            return true
+            -- NOTE: keep existing behavior for local call which only set type based on the 1st match
+            if func.parent.type == 'callargs' then
+                return true
+            end
+            found = true
         end
+    end
+    if found then
+        return true
     end
 
     local derviationParam = config.get(guide.getUri(func), 'Lua.type.inferParamType')

--- a/test/type_inference/param_match.lua
+++ b/test/type_inference/param_match.lua
@@ -172,6 +172,44 @@ local v = 'y'
 local <?r?> = f(v)
 ]]
 
+TEST 'string|number' [[
+---@overload fun(a: string)
+---@overload fun(a: number)
+local function f(<?a?>) end
+]]
+
+TEST '1|2' [[
+---@overload fun(a: 1)
+---@overload fun(a: 2)
+local function f(<?a?>) end
+]]
+
+TEST 'string' [[
+---@overload fun(a: 1): string
+---@overload fun(a: 2): number
+local function f(a) end
+
+local <?r?> = f(1)
+]]
+
+TEST 'number' [[
+---@overload fun(a: 1): string
+---@overload fun(a: 2): number
+local function f(a) end
+
+local <?r?> = f(2)
+]]
+
+TEST 'string|number' [[
+---@overload fun(a: 1): string
+---@overload fun(a: 2): number
+local function f(a) end
+
+---@type number
+local v
+local <?r?> = f(v)
+]]
+
 TEST 'number' [[
 ---@overload fun(a: 1, c: fun(x: number))
 ---@overload fun(a: 2, c: fun(x: string))


### PR DESCRIPTION
fix #2509, fix #2708, fix #2709
(this logic has to be based on #2822, otherwise might cause other issues in type narrow behavior)

## Promblem

When a function only has `@overload` annotation, the function itself will auto infer its params' type by using **only the 1st overload type**, combined with the **return type** of the function body logic, thus create an incorrect **base function** when doing function match.

### Minimal Example
```lua
---@overload fun(a: 1): string
---@overload fun(a: 2): number
local function f(a) end --> fun(a: 1): nil

-- here the `a` in `f()` are inferred by the 1st `@overload` -> `a: 1`
-- and then it combines the return type `nil` due to the empty function body
-- => overall gives an incorrect `fun(a: 1): nil` as the base function signature

local r = f(1)  --> string|nil, bad
-- because it matches both the overload and the "baseline" function
```

## Proposed Solution

Just ignore the baseline function type when it is annotated with **only `@overload`**.
In case the function has at least one `@param` or `@return`, then keep the existing behavior.

### Expected Result
```lua
---@overload fun(a: 1): string
---@overload fun(a: 2): number
local function f(a) end --> fun(a: 1|2): nil, but we don't care about this anymore

local r = f(1)  --> string, good
-- now the "baseline" function type is ignored, will only found the overload one
```

---

## 中文版

這個其實是 #2822 的延續，上次說怕一次改太多會出 bug，所以拆分 PR

當前在一個 function 只有 `@overload` 的情況下，這 function 的 type 會直接從 **第一個** overload 獲取
更甚者是還會結合 function body logic 自身的 return type (在寫 `@meta` 時很大可能是 `nil`，因為是 empty function body)
- 結果就會得出一個錯誤的 baseline function type
- 在後續做 matching 時就會出問題，比如說把這個 baseline function type 的 `return nil` 也當成一種 union return type
- 具體例子見上邊

這裡解決方式是當 function **只有 `@overload`** 時，就忽略這個 baseline function type，只從 overload 中做 match
有如當 function 是單純 `local f(...)` 全 vararg 時就直接忽略
反過來說如果 function 有至少1個 `@param` 或 `@return` => 維持現有 behavior

應該也是需要 @sumneko 來 review
