### PR TITLE
Fix correctly display enums for function overload arguments

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@
 * `FIX` Fix `VM.OnCompileFunctionParam` function in plugins
 * `FIX` Lua 5.1: fix incorrect warning when using setfenv with an int as first parameter
 * `FIX` Improve type narrow by checking exact match on literal type params
+* `FIX` Correctly list enums for function overload arguments [#2840](https://github.com/LuaLS/lua-language-server/pull/2840)
 
 ## 3.10.5
 `2024-8-19`

--- a/script/core/completion/completion.lua
+++ b/script/core/completion/completion.lua
@@ -78,7 +78,9 @@ local function findNearestSource(state, position)
     ---@type parser.object
     local source
     guide.eachSourceContain(state.ast, position, function (src)
-        source = src
+        if not source or source.start <= src.start then
+            source = src
+        end
     end)
     return source
 end


### PR DESCRIPTION
to achieve this bug requires function overloading and multiple variable assignment.

```lua
---@return string, number
---@overload fun(s: "test", a?:number):name:"name", string
function test() end

local name, aString = test("|") --- can see "test" and "name", only "test" is expected
```
using the debugger I go back to the `findNearestSource` function which does not see the correct source.
`guide.eachSourceContain` only returns the same source once, so you need to check if it is closer.
```lua
local function findNearestSource(state, position)
    ---@type parser.object
    local source
    guide.eachSourceContain(state.ast, position, function (src)
        if not source or source.start <= src.start then
            source = src
        end
    end)
    return source
end
```