### PR TITLE
Fixed injects into child classes

### DIFF
--- a/script/vm/compiler.lua
+++ b/script/vm/compiler.lua
@@ -101,6 +101,26 @@ local function searchFieldByLocalID(source, key, pushResult)
     if not fields then
         return
     end
+
+    --Exact classes do not allow injected fields
+    if source.type ~= 'variable' and source.bindDocs then
+        ---@cast source parser.object
+        local uri = guide.getUri(source)
+        for _, src in ipairs(fields) do
+            if src.type == "setfield" then
+                local class = vm.getDefinedClass(uri, source)
+                if class then
+                    for _, doc in ipairs(class:getSets(uri)) do
+                        if vm.docHasAttr(doc, 'exact') then
+                            return
+                        end
+                    end
+                end
+            end
+        end
+    end
+    
+
     local hasMarkDoc = {}
     for _, src in ipairs(fields) do
         if src.bindDocs then


### PR DESCRIPTION
https://github.com/LuaLS/lua-language-server/issues/2573

This change handles "cannot be injected" correctly if the field member is inherited.

```lua
---@class (exact) A
---@field test number
local a = {}

function a:init()
    --This is fine
    self.test = 0
end

---@class (exact) B : A
local b = {}

function b:init()
    --This is an injection and thus invalid
    self.test = 0

    --This is an actual injection and will remain invalid
    self.test2 = 0
end
```