### PR TITLE
Only call workspace/configuration when available

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@
 * `FIX` Improve type narrow by checking exact match on literal type params
 * `FIX` Correctly list enums for function overload arguments [#2840](https://github.com/LuaLS/lua-language-server/pull/2840)
 * `FIX` Incorrect function params' type infer when there is only `@overload` [#2509](https://github.com/LuaLS/lua-language-server/issues/2509) [#2708](https://github.com/LuaLS/lua-language-server/issues/2708) [#2709](https://github.com/LuaLS/lua-language-server/issues/2709)
+* `FIX` Only call workspace/configuration when available [#981](https://github.com/LuaLS/lua-language-server/issues/981), [#2318](https://github.com/LuaLS/lua-language-server/issues/2318), [2336](https://github.com/LuaLS/lua-language-server/issues/2336) [#2843](https://github.com/LuaLS/lua-language-server/pull/2843)
 
 ## 3.10.5
 `2024-8-19`

--- a/script/lclient.lua
+++ b/script/lclient.lua
@@ -83,6 +83,9 @@ local defaultClientOptions = {
                 },
             },
         },
+        workspace = {
+            configuration = true,
+        },
     },
 }
 

--- a/script/provider/provider.lua
+++ b/script/provider/provider.lua
@@ -41,7 +41,10 @@ function m.updateConfig(uri)
     end
 
     for _, folder in ipairs(scope.folders) do
-        local clientConfig = cfgLoader.loadClientConfig(folder.uri)
+        local clientConfig = nil
+        if client.getAbility('workspace.configuration') then
+            clientConfig = cfgLoader.loadClientConfig(folder.uri)
+        end
         if clientConfig then
             log.info('Load config from client', folder.uri)
             log.info(inspect(clientConfig))
@@ -57,10 +60,12 @@ function m.updateConfig(uri)
         config.update(folder, clientConfig, rc)
     end
 
-    local global = cfgLoader.loadClientConfig()
-    log.info('Load config from client', 'fallback')
-    log.info(inspect(global))
-    config.update(scope.fallback, global)
+    if client.getAbility('workspace.configuration') then
+        local global = cfgLoader.loadClientConfig()
+        log.info('Load config from client', 'fallback')
+        log.info(inspect(global))
+        config.update(scope.fallback, global)
+    end
 end
 
 function m.register(method)


### PR DESCRIPTION
Happy first birthday, issue #2318!

During its first year of existance, issue #2318 has failed to get any attention at all from the project maintainers. Even though it addresses a fundamental bug. A couple of people have commented that the patch has helped them, from which we can derive that probably many more are using the patched version without bothering to comment.

Not that I believe the existence of a pull request will change anything, but lets give this a try.

As previously communicated, I do not read simplified chinese. So someone else will need to update the remaining test cases or translate and rework the explanatory comments into English. Disabling or removing broken tests would be an option as well, of course. Yet, then again, with other tests already failing on master one might as well also consider merging this commit as is.


Commit message follows: (written a year ago when first submitted, but the basic facts hasn't changed.)

Not all clients implement the client capability: `configuration`, which was added in version 3.6.0 of the Language Server Protocol. The LSP Specification also states:

> A missing property should be interpreted as an absence of the capability.

Above claims are possible to verify by reading the mentioned spec. at: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_configuration

Hence this change modifies behaviour to only call the method on clients explicitly announcing to support it.

Most affected test-cases are updated to work with this commit, however one test gets disabled. That disabled test suite is in serious need of added documentation explaining its design. The few comments which are there seem highly unsufficient, and since they are written in simplified chinese they practically are of no use to most potential contributors.

This commit makes the lua-language-server work with vim-ale.