### PR TITLE
Remove luamake install from make.sh and make.bat

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ## Unreleased
 <!-- Add all new changes here. They will be moved under a version at release -->
 * `NEW` Added support for Japanese locale
+* `FIX` Remove luamake install from make scripts
 
 ## 3.10.6
 `2024-9-10`

--- a/make.bat
+++ b/make.bat
@@ -1,6 +1,5 @@
 git submodule update --init --recursive
 cd 3rd\luamake
-call compile\install.bat
 call compile\build.bat
 cd ..\..
 IF "%~1"=="" (

--- a/make.sh
+++ b/make.sh
@@ -2,7 +2,6 @@
 
 git submodule update --init --recursive
 pushd 3rd/luamake
-./compile/install.sh
 ./compile/build.sh
 popd
 if [ -z "$1" ]; then


### PR DESCRIPTION
These scripts call the newly compiled luamake binary directly as `3rd/luamake/luamake` so there's no need for it to be installed or added to the user's PATH globally and permanently.

More generally, the `make` command for a single project should not be writing to the user's `.bashrc` or `.zshrc`.