### PR TITLE
Use `string.format` to fix floating point error in test output

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ## Unreleased
 <!-- Add all new changes here. They will be moved under a version at release -->
 * `NEW` Added support for Japanese locale
+* `FIX` Eliminate floating point error in test benchmark output
 
 ## 3.10.6
 `2024-9-10`

--- a/test/full/projects.lua
+++ b/test/full/projects.lua
@@ -49,7 +49,7 @@ local function doProjects(pathname)
     for uri in files.eachFile() do
         local fileClock = os.clock()
         diag.doDiagnostic(uri, true)
-        print('诊断文件耗时：', os.clock() - fileClock, uri)
+        print('诊断文件耗时：', string.format("%.6f", os.clock() - fileClock), uri)
     end
 
     local passed = os.clock() - clock

--- a/test/full/self.lua
+++ b/test/full/self.lua
@@ -48,7 +48,7 @@ for uri in files.eachFile() do
     end)
     local fileClock = os.clock()
     diag.doDiagnostic(uri, true)
-    print('诊断文件耗时：', os.clock() - fileClock, uri)
+    print('诊断文件耗时：', string.format("%.6f", os.clock() - fileClock), uri)
     ::CONTINUE::
 end
 


### PR DESCRIPTION
Floating point error causes some test benchmark times to have a bunch of trailing 9s or 0s before some noise at the end.

Before:
```
诊断文件耗时：  0.0048709999999978      file:///Users/sparr/src/lua-language-server/script/SDBMHash.lua
诊断文件耗时：  0.545929        file:///Users/sparr/src/lua-language-server/script/await.lua
诊断文件耗时：  0.0079290000000007      file:///Users/sparr/src/lua-language-server/script/brave/log.lua
```
After:
```
诊断文件耗时：  0.004871        file:///Users/sparr/src/lua-language-server/script/SDBMHash.lua
诊断文件耗时：  0.545929        file:///Users/sparr/src/lua-language-server/script/await.lua
诊断文件耗时：  0.007929        file:///Users/sparr/src/lua-language-server/script/brave/log.lua
```