### PR TITLE
Infer function parameter types when overriding the same-named class function in an instance of that class

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ## Unreleased
 <!-- Add all new changes here. They will be moved under a version at release -->
 * `NEW` Added support for Japanese locale
+* `NEW` Infer function parameter types when overriding the same-named class function in an instance of that class [#2158](https://github.com/LuaLS/lua-language-server/issues/2158)
 
 ## 3.10.6
 `2024-9-10`

--- a/script/core/diagnostics/duplicate-set-field.lua
+++ b/script/core/diagnostics/duplicate-set-field.lua
@@ -68,6 +68,12 @@ return function (uri, callback)
             if not defValue or defValue.type ~= 'function' then
                 goto CONTINUE
             end
+            if vm.getDefinedClass(guide.getUri(def), def.node)
+            and not vm.getDefinedClass(guide.getUri(src), src.node)
+            then
+                -- allow type variable to override function defined in class variable
+                goto CONTINUE
+            end
             callback {
                 start   = src.start,
                 finish  = src.finish,

--- a/script/vm/compiler.lua
+++ b/script/vm/compiler.lua
@@ -1117,26 +1117,56 @@ local function compileFunctionParam(func, source)
     end
     ---@cast aindex integer
 
-    -- local call ---@type fun(f: fun(x: number));call(function (x) end) --> x -> number
     local funcNode = vm.compileNode(func)
-    local found = false
-    for n in funcNode:eachObject() do
-        if n.type == 'doc.type.function' and n.args[aindex] then
-            local argNode = vm.compileNode(n.args[aindex])
-            for an in argNode:eachObject() do
-                if an.type ~= 'doc.generic.name' then
-                    vm.setNode(source, an)
+    if func.parent.type == 'callargs' then
+        -- local call ---@type fun(f: fun(x: number));call(function (x) end) --> x -> number
+        for n in funcNode:eachObject() do
+            if n.type == 'doc.type.function' and n.args[aindex] then
+                local argNode = vm.compileNode(n.args[aindex])
+                for an in argNode:eachObject() do
+                    if an.type ~= 'doc.generic.name' then
+                        vm.setNode(source, an)
+                    end
                 end
-            end
-            -- NOTE: keep existing behavior for local call which only set type based on the 1st match
-            if func.parent.type == 'callargs' then
+                -- NOTE: keep existing behavior for function as argument which only set type based on the 1st match
                 return true
             end
-            found = true
         end
-    end
-    if found then
-        return true
+    else
+        -- function declaration: use info from all `fun()`, also from the base function when overriding
+        --[[
+            ---@type fun(x: string)|fun(x: number)
+            local function f1(x) end --> x -> string|number
+
+            ---@overload fun(x: string)
+            ---@overload fun(x: number)
+            local function f2(x) end --> x -> string|number
+
+            ---@class A
+            local A = {}
+            ---@param x number
+            function A:f(x) end --> x -> number
+            ---@type A
+            local a = {}
+            function a:f(x) end --> x -> number
+        ]]
+        local found = false
+        for n in funcNode:eachObject() do
+            if (n.type == 'doc.type.function' or n.type == 'function')
+            and n.args[aindex] and n.args[aindex] ~= source
+            then
+                local argNode = vm.compileNode(n.args[aindex])
+                for an in argNode:eachObject() do
+                    if an.type ~= 'doc.generic.name' then
+                        vm.setNode(source, an)
+                    end
+                end
+                found = true
+            end
+        end
+        if found then
+            return true
+        end
     end
 
     local derviationParam = config.get(guide.getUri(func), 'Lua.type.inferParamType')

--- a/test/diagnostics/duplicate-set-field.lua
+++ b/test/diagnostics/duplicate-set-field.lua
@@ -72,3 +72,29 @@ else
     function X.f() end
 end
 ]]
+
+TEST [[
+---@class A
+X = {}
+
+function X:f() end
+
+---@type x
+local x
+
+function x:f() end
+]]
+
+TEST [[
+---@class A
+X = {}
+
+function X:f() end
+
+---@type x
+local x
+
+function <!x:f!>() end
+
+function <!x:f!>() end
+]]

--- a/test/type_inference/common.lua
+++ b/test/type_inference/common.lua
@@ -4441,3 +4441,15 @@ local B = {}
 
 function B:func(<?x?>) end
 ]]
+
+TEST 'number' [[
+---@class A
+local A = {}
+
+---@param x number
+function A:func(x) end
+
+---@type A
+local a = {}
+function a:func(<?x?>) end
+]]


### PR DESCRIPTION
resolves #2158, https://github.com/LuaLS/lua-language-server/issues/2569#issuecomment-2342854384

## The problem
Sometimes we will want to define interface for overriding in **instance object of that class**, and retain the param types defined in the interface while overriding. But currently no way to do so as described in #2158 and https://github.com/LuaLS/lua-language-server/issues/2569#issuecomment-2342854384
```lua
---@class A
local A = {}

---@return A
function A.new() end

---@param x number
function A:user_callback(x) end

local a = A.new()
function a:user_callback(x) end -- no type infer for `x`, also throwing `duplicate-set-field` warning
```

## Proposed change
Detailed explanation here: https://github.com/LuaLS/lua-language-server/issues/2569#issuecomment-2350869680

## Expected Result
```lua
---@class A
local A = {}

---@return A
function A.new() end

---@param x number
function A:user_callback(x) end

local a = A.new()
function a:user_callback(x)
    -- x -> number
    -- and no more `duplicate-set-field` warning :)
end
```

## Additional notes
- The way that I modified `duplicate-set-field` diagnostic is **allowing an `instance variable` to override any of its `class function/method`**.
i.e. all function/methods from a class can be overriden in variable of that type, without any `duplicate-set-field` warning.
- This auto infer only works in a **class variable / instance variable** pair ✅ 
i.e. it doesn't work when the namespace is just a global variable ❌ 
```lua
--- file a
global_namespace = {}

---@param x number
function global_namespace.user_callback(x) end

--- file b
function global_namespace.user_callback(x)
    -- this will not work, because this is not in `class/type` variable pair
end
```
- I believe a `@override` will be definitely needed for that case, as otherwise no way to distinguish between setting duplicate field or really doing override 😕 

---

## 中文版

- 支持在 instance variable 下 override 其 class function 時做 auto param type infer
- 同時忽略在這種 use case 下的 `duplicate-set-field` warning
- 這個只針對 `class/type` variable 組合下的 override 場景 (例子見上邊)
    - 並不處理 define 成 global namespace 後再做 override 的使用場景
    - 該種 use case 似必需等待 `@override` 語法支持了，否則不能區分是出現 duplicate 還是真的想 override
