### PR TITLE
add: placeholder for ${addons} for paths

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@
 * `FIX` Eliminate floating point error in test benchmark output
 * `FIX` Remove luamake install from make scripts
 * `NEW` Types with literal fields can be narrowed.
+* `NEW` Reference addons installed via the addon manager with `${addons}` [#2866](https://github.com/LuaLS/lua-language-server/pull/2866).
 
 ## 3.10.6
 `2024-9-10`

--- a/script/files.lua
+++ b/script/files.lua
@@ -908,18 +908,43 @@ function m.countStates()
     return n
 end
 
+---Resolve path variables/placeholders like ${3rd} and ${addons}
 ---@param path string
----@return string
-function m.normalize(path)
-    path = path:gsub('%$%{(.-)%}', function (key)
-        if key == '3rd' then
-            return (ROOT / 'meta' / '3rd'):string()
-        end
-        if key:sub(1, 4) == 'env:' then
+---@return string resolvedPath
+function m.resolvePathPlaceholders(path)
+    path = path:gsub("%$%{(.-)%}", function(key)
+        if key == "3rd" then
+            return (ROOT / "meta" / "3rd"):string()
+        elseif key == "addons" then
+            -- Common path across OSes
+            local dataPath = "User/globalStorage/sumneko.lua/addonManager/addons"
+
+            if platform.os == "windows" then
+                return "$APPDATA/Code/" .. dataPath
+            elseif platform.os == "linux" then
+                local serverPath = util.expandPath(fs.path("~/.vscode-server/data"):string())
+                if fs.exists(serverPath) then
+                    -- addons are installed via SSH remote
+                    return serverPath .."/" .. dataPath
+                else
+                    return "~/.config/Code/" .. dataPath
+                end
+            elseif platform.os == "macos" then
+                return "~/Library/Application/Support/Code/" .. dataPath
+            end
+        elseif key:sub(1, 4) == "env:" then
             local env = os.getenv(key:sub(5))
             return env
         end
     end)
+
+    return path
+end
+
+---@param path string
+---@return string
+function m.normalize(path)
+    path = m.resolvePathPlaceholders(path)
     path = util.expandPath(path)
     path = path:gsub('^%.[/\\]+', '')
     for _ = 1, 1000 do


### PR DESCRIPTION
Finally doing what was [promised long ago](https://github.com/LuaLS/lua-language-server/discussions/1950#discussioncomment-7547044) and adding an `${addons}` variable/placeholder for paths so that people can specify, for example, `${addons}/busted/module/library` and it will resolve to the installation location for the addon manager.

There are a lot of different platforms, which I could not all test myself. I have tested a few though:

- [x] Windows
- [x] WSL
- [ ] Linux
- [x] Linux over SSH remote
- [ ] MacOS

The proper solution is probably to change the installation location for addons from the addon manager to go to `~/.luals/addons` rather than wherever VS Code has decided to throw them. It would then hopefully be much easier to find them and would be less dependent on VS Code. Something to keep in mind for the new addon manager, but unlikely to be implemented soon.