### PR TITLE
add classes for each parser.object type

### DIFF
--- a/script/parser/luadoc.lua
+++ b/script/parser/luadoc.lua
@@ -139,7 +139,7 @@ Symbol              <-  ({} {
 
 ---@alias parser.visibleType 'public' | 'protected' | 'private' | 'package'
 
----@class parser.object
+---@class parser.object.base
 ---@field literal           boolean
 ---@field signs             parser.object[]
 ---@field originalComment   parser.object

--- a/script/vm/doc.lua
+++ b/script/vm/doc.lua
@@ -4,7 +4,7 @@ local guide     = require 'parser.guide'
 local vm        = require 'vm.vm'
 local config    = require 'config'
 
----@class parser.object
+---@class parser.object.base
 ---@field package _castTargetHead? parser.object | vm.global | false
 ---@field package _validVersions? table<string, boolean>
 ---@field package _deprecated? parser.object | false

--- a/script/vm/generic.lua
+++ b/script/vm/generic.lua
@@ -1,7 +1,7 @@
 ---@class vm
 local vm      = require 'vm.vm'
 
----@class parser.object
+---@class parser.object.base
 ---@field package _generic vm.generic
 ---@field package _resolved vm.node
 

--- a/script/vm/global.lua
+++ b/script/vm/global.lua
@@ -10,7 +10,7 @@ local allGlobals = {}
 ---@type table<uri, table<string, boolean>>
 local globalSubs = util.multiTable(2)
 
----@class parser.object
+---@class parser.object.base
 ---@field package _globalBase parser.object
 ---@field package _globalBaseMap table<string, parser.object>
 ---@field global vm.global
@@ -168,7 +168,7 @@ local function createGlobal(name, cate)
     }, mt)
 end
 
----@class parser.object
+---@class parser.object.base
 ---@field package _globalNode vm.global|false
 ---@field package _enums?     parser.object[]
 

--- a/script/vm/sign.lua
+++ b/script/vm/sign.lua
@@ -273,7 +273,7 @@ function vm.createSign()
     return genericMgr
 end
 
----@class parser.object
+---@class parser.object.base
 ---@field package _sign vm.sign|false|nil
 
 ---@param source parser.object

--- a/script/vm/tracer.lua
+++ b/script/vm/tracer.lua
@@ -3,7 +3,7 @@ local vm        = require 'vm.vm'
 local guide     = require 'parser.guide'
 local util      = require 'utility'
 
----@class parser.object
+---@class parser.object.base
 ---@field package _tracer? vm.tracer
 ---@field package _casts?  parser.object[]
 

--- a/script/vm/variable.lua
+++ b/script/vm/variable.lua
@@ -27,7 +27,7 @@ local function createVariable(root, id)
     return variable
 end
 
----@class parser.object
+---@class parser.object.base
 ---@field package _variableNode vm.variable|false
 ---@field package _variableNodes table<string, vm.variable>
 

--- a/script/vm/visible.lua
+++ b/script/vm/visible.lua
@@ -4,7 +4,7 @@ local guide    = require 'parser.guide'
 local config   = require 'config'
 local glob     = require 'glob'
 
----@class parser.object
+---@class parser.object.base
 ---@field package _visibleType? parser.visibleType
 
 local function globMatch(patterns, fieldName)


### PR DESCRIPTION
Now LuaLS can narrow types based on literal fields (see #2864), I've began to break out `parser.object` into smaller classes that contain the exact fields for each.

This results in a lot of type warnings for `script/vm/*` that may be difficult to resolve.

Is this something that is worth pursuing or would it be preferred to maintain `parser.object` are a large class with lots of optional fields?
