### PR TITLE
Return markdown from getFunctionComment to temporarily preserve trailing newlines

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ## Unreleased
 <!-- Add all new changes here. They will be moved under a version at release -->
 * `FIX` Fixed an issue preventing to set the locale to Japanese
+* `FIX` Preserve newlines between function comment and @see
 
 ## 3.11.0
 * `NEW` Added support for Japanese locale

--- a/script/core/hover/description.lua
+++ b/script/core/hover/description.lua
@@ -336,7 +336,7 @@ local function tryDocFieldComment(source)
     end
 end
 
-local function getFunctionComment(source, raw)
+local function getFunctionCommentMarkdown(source, raw)
     local docGroup = source.bindDocs
     if not docGroup then
         return
@@ -393,11 +393,7 @@ local function getFunctionComment(source, raw)
     local enums = getBindEnums(source, docGroup)
     md:add('lua', enums)
 
-    local comment = md:string()
-    if comment == '' then
-        return nil
-    end
-    return comment
+    return md
 end
 
 ---@async
@@ -407,8 +403,7 @@ local function tryDocComment(source, raw)
         source = source.value
     end
     if source.type == 'function' then
-        local comment = getFunctionComment(source, raw)
-        md:add('md', comment)
+        md:add('md', getFunctionCommentMarkdown(source, raw))
         source = source.parent
     end
     local comment = lookUpDocComments(source)


### PR DESCRIPTION
FIXES #2887 

Thanks to @tomlau10 for this idea.

I've tested in a few scenarios and the results are promising. `@see` is still appended without a newline if there's comment content above it and no params to separate them in the rendered output, but an explicit empty comment line above it will force it onto its own new line. Making it always on a new line may be preferable, but that would be a bigger change.