### PR TITLE
Handle alternate linux config directory paths for addons

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ## Unreleased
 <!-- Add all new changes here. They will be moved under a version at release -->
 * `FIX` Fixed an issue preventing to set the locale to Japanese
+* `FIX` Handle alternate linux config directory paths for addons
 
 ## 3.11.0
 * `NEW` Added support for Japanese locale


### PR DESCRIPTION
Microsoft's build of VSCode uses `~/.config/Code` on Linux. Popular alternate builds VSCodium and Code - OSS use different names for their config directories. And if a distro or user compiles with an uncommon name, it could be arbitrary.

This patch checks the three named variations, then all config dirs, then produces an error.

I also had it memoize the addons path rather than search for it 3+ times during startup (once for every instance of `${addons}`)

This fixes the problem I ran into in https://github.com/LuaLS/LLS-Addons/pull/182