### PR TITLE
Add storagePath handling and memoization to resolvePathPlaceholders

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ## Unreleased
 <!-- Add all new changes here. They will be moved under a version at release -->
 * `FIX` Fixed an issue preventing to set the locale to Japanese
+* `FIX` Accept storagePath option from client to resolve addon directory not found
 
 ## 3.11.0
 * `NEW` Added support for Japanese locale

--- a/script/files.lua
+++ b/script/files.lua
@@ -906,6 +906,8 @@ function m.countStates()
     return n
 end
 
+local addonsPath
+
 ---Resolve path variables/placeholders like ${3rd} and ${addons}
 ---@param path string
 ---@return string resolvedPath
@@ -914,22 +916,32 @@ function m.resolvePathPlaceholders(path)
         if key == "3rd" then
             return (ROOT / "meta" / "3rd"):string()
         elseif key == "addons" then
-            -- Common path across OSes
-            local dataPath = "User/globalStorage/sumneko.lua/addonManager/addons"
-
-            if platform.os == "windows" then
-                return "$APPDATA/Code/" .. dataPath
-            elseif platform.os == "linux" then
-                local serverPath = util.expandPath(fs.path("~/.vscode-server/data"):string())
-                if fs.exists(serverPath) then
-                    -- addons are installed via SSH remote
-                    return serverPath .."/" .. dataPath
-                else
-                    return "~/.config/Code/" .. dataPath
-                end
-            elseif platform.os == "macos" then
-                return "~/Library/Application Support/Code/" .. dataPath
+            if addonsPath then
+                return addonsPath
             end
+            local client = require 'client'
+            local storagePath = client.getOption('storagePath')
+            if storagePath then
+                addonsPath = storagePath .. "/addonManager/addons"
+            else
+                -- Common path across OSes
+                local dataPath = "User/globalStorage/sumneko.lua/addonManager/addons"
+
+                if platform.os == "windows" then
+                    addonsPath = "$APPDATA/Code/" .. dataPath
+                elseif platform.os == "linux" then
+                    local serverPath = util.expandPath(fs.path("~/.vscode-server/data"):string())
+                    if fs.exists(serverPath) then
+                        -- addons are installed via SSH remote
+                        addonsPath = serverPath .."/" .. dataPath
+                    else
+                        addonsPath = "~/.config/Code/" .. dataPath
+                    end
+                elseif platform.os == "macos" then
+                    addonsPath = "~/Library/Application Support/Code/" .. dataPath
+                end
+            end
+            return addonsPath
         elseif key:sub(1, 4) == "env:" then
             local env = os.getenv(key:sub(5))
             return env


### PR DESCRIPTION
This is an alternative to #2892 following the suggestion to allow the client to tell the server where addon files should be stored. I again memoized the result to avoid looking it up many times.

Matching PR on the other side: https://github.com/LuaLS/vscode-lua/pull/150

I have tested this on EndeavourOS (~Arch Linux), but cannot currently test on mac or windows.