### PR TITLE
Change global variable token to definition

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 <!-- Add all new changes here. They will be moved under a version at release -->
+* `CHG` Change the default TokenModifier from global variables from 'global' to 'readonly'.
 
 ## 3.11.1
 `2024-10-9`

--- a/script/core/semantic-tokens.lua
+++ b/script/core/semantic-tokens.lua
@@ -36,7 +36,7 @@ local Care = util.switch()
         local isFunc = vm.getInfer(source):hasFunction(guide.getUri(source))
 
         local type = isFunc and define.TokenTypes['function'] or define.TokenTypes.variable
-        local modifier = isLib and define.TokenModifiers.defaultLibrary or define.TokenModifiers.global
+        local modifier = isLib and define.TokenModifiers.defaultLibrary or define.TokenModifiers.readonly
 
         results[#results+1] = {
             start      = source.start,


### PR DESCRIPTION
Fixing the issue: https://github.com/LuaLS/lua-language-server/issues/2646

The TokenModifier global isn't is a default token to vscode documentation ([doc](https://code.visualstudio.com/api/language-extensions/semantic-highlight-guide#standard-token-types-and-modifiers)). This change will set the default global colors to a different color from local variables.
The token static is another option, but some themes don't define this color too.

Using for a time this change i noticed an improve in coding from my team, because this avoid some word misstakes and they can visually check if they write some variable wrong. And they don't need to change any configuration inside the vscode to define "global" in any theme.