### PR TITLE
fix: regression related to type narrow and generic since v3.10.1

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 <!-- Add all new changes here. They will be moved under a version at release -->
+* `FIX` A regression related to type narrow and generic param introduced since `v3.10.1`
 
 ## 3.11.1
 `2024-10-9`

--- a/script/vm/compiler.lua
+++ b/script/vm/compiler.lua
@@ -630,15 +630,17 @@ local function matchCall(source)
         newNode.originNode = myNode
         vm.setNode(source, newNode, true)
         if call.args then
-            -- clear node caches of args to allow recomputation with the type narrowed call
+            -- clear existing node caches of args to allow recomputation with the type narrowed call
             for _, arg in ipairs(call.args) do
-                vm.setNode(arg, vm.createNode(), true)
+                if vm.getNode(arg) then
+                    vm.setNode(arg, vm.createNode(), true)
+                end
             end
             for n in newNode:eachObject() do
                 if n.type == 'function'
                 or n.type == 'doc.type.function' then
                     for i, arg in ipairs(call.args) do
-                        if n.args[i] then
+                        if vm.getNode(arg) and n.args[i] then
                             vm.setNode(arg, vm.compileNode(n.args[i]))
                         end
                     end

--- a/test/type_inference/common.lua
+++ b/test/type_inference/common.lua
@@ -4571,3 +4571,23 @@ else
     local <?b?> = a
 end
 ]]
+
+TEST 'nil' [[
+---@generic T
+---@param v T
+---@return T
+---@overload fun(): nil
+local function f(v) end
+
+local <?r?> = f()
+]]
+
+TEST 'string' [[
+---@generic T
+---@param v T
+---@return T
+---@overload fun(): nil
+local function f(v) end
+
+local <?r?> = f('')
+]]


### PR DESCRIPTION
While giving reply in an old issue, I found a regression issue related to `@overload` and `@generic`: https://github.com/LuaLS/lua-language-server/issues/723#issuecomment-2408837943
After doing **git bisect**, I found that it is introduced in this commit of `v3.10.1` : https://github.com/LuaLS/lua-language-server/commit/8ecec08

## Minimal Example
```lua
---@generic T
---@param v T
---@return T
local function f1(v) end
local r1 = f1(1) --> integer, good

---@generic T
---@param v T
---@return T
---@overload fun(): nil
local function f2(v) end
local r2 = f2(1) --> unknown, bad
```

## Expected Result
```lua
---@generic T
---@param v T
---@return T
---@overload fun(): nil
local function f2(v) end
local r2 = f2(1) --> integer, good
```

---
## 中文版

我在回覆一個舊 issue 的時候，發現一個關於 `@overload` 及 `@generic` 的 regression 問題，具體例子見上邊。
大概是當 function 同時有 overload 和 generic param，並且 overload 的 function signature **比帶 generic 的短** 就會觸發 (?)

用 git bisect 找到是這個 commit 開始出現的: https://github.com/LuaLS/lua-language-server/commit/8ecec08
這個 commit 當時是為了 fix #2765 所引起的 runtime error，所以可以肯定是 bugfix commit 引起了不知明 side effect 🤔 

### 估計成因
- 當時 #2765 是為了讓 `call.args` 能在 type narrow 後做 recompute，所以直接把 `call.args` 的 node cache 刪掉了，但卻有可能引起 runtime error
- 而 https://github.com/LuaLS/lua-language-server/commit/8ecec08 的 fix 則是 **直接將所有 `call.args` node cache 先設成 empty** 來解決 runtime error
- 我懷疑是如果某個 `call.args` 的 node cache 本身未存在，就直接設成 empty object，反而會引起之後的 infer 錯誤
=> empty infer => 就是 `unknown` 🤔 
- 所以這裡的 fix 是 **只有 `vm.getNode()` 存在** 時，才會 overwrite 成 empty new node