### PR TITLE
Fix vararg indices being unknown when iterated

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ## Unreleased
 <!-- Add all new changes here. They will be moved under a version at release -->
 * `FIX` A regression related to type narrow and generic param introduced since `v3.10.1`
+* `FIX` Determine that the index of `{...}` is an integer when iterating
 
 ## 3.11.1
 `2024-10-9`

--- a/script/vm/type.lua
+++ b/script/vm/type.lua
@@ -721,7 +721,7 @@ function vm.getTableKey(uri, tnode, vnode, reverse)
                 if field.type == 'tablefield' then
                     result:merge(vm.declareGlobal('type', 'string'))
                 end
-                if field.type == 'tableexp' then
+                if field.type == 'tableexp' or field.type == 'varargs' then
                     result:merge(vm.declareGlobal('type', 'integer'))
                 end
             end

--- a/test/type_inference/common.lua
+++ b/test/type_inference/common.lua
@@ -4591,3 +4591,11 @@ local function f(v) end
 
 local <?r?> = f('')
 ]]
+
+TEST 'integer' [[
+local function F(...)
+    local t = {...}
+    for <?k?> in pairs(t) do
+    end
+end
+]]


### PR DESCRIPTION
Big thanks to @tomlau10 for basically writing the fix for me.

After some testing and trying any weird thing I could think of to break the fix, it seemed pretty bulletproof, but I wouldn't be surprised if I'm just not creative enough.

I went ahead and added a test and an entry to the changelog.
This is my first time contributing to luals, so I'd love constructive feedback. Like I feel like my wording is bad no matter how I think about wording things :grin:

FIXES #2906