### PR TITLE
[reference] Check also in tablefield

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ## Unreleased
 <!-- Add all new changes here. They will be moved under a version at release -->
 * `FIX` A regression related to type narrow and generic param introduced since `v3.10.1`
+* `FIX` Reference should also look in tablefield
 
 ## 3.11.1
 `2024-10-9`

--- a/script/vm/ref.lua
+++ b/script/vm/ref.lua
@@ -109,7 +109,7 @@ local function searchWord(source, pushResult, defMap, fileNotify)
             end)
         end
         ---@async
-        guide.eachSourceTypes(state.ast, {'getfield', 'setfield'}, function (src)
+        guide.eachSourceTypes(state.ast, {'getfield', 'setfield', 'tablefield'}, function (src)
             if src.field and src.field[1] == key then
                 checkDef(src)
                 await.delay()

--- a/test/references/all.lua
+++ b/test/references/all.lua
@@ -139,3 +139,13 @@ function TestB(param)
     param:<!TestA!>()
 end
 ]]
+
+TEST [[
+---@class A
+---@field <~x~> number
+
+---@type A
+local t = {
+    <!x!> = 1
+}
+]]


### PR DESCRIPTION
We had a problem that in this code:
```
---@class A
---@field x number

---@type A
local a = {
    x = 4
}
```
VSCode can't find this reference. 

After fixing it, it works fine : )

![output](https://github.com/user-attachments/assets/52faf134-8688-4dd1-a32f-7a747dae9cea)
