### PR TITLE
fix: parse storage path

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ## Unreleased
 <!-- Add all new changes here. They will be moved under a version at release -->
 * `FIX` A regression related to type narrow and generic param introduced since `v3.10.1`
+* `FIX` Parse storagePath to improve reliability of resolving ${addons} placeholder
 
 ## 3.11.1
 `2024-10-9`

--- a/script/files.lua
+++ b/script/files.lua
@@ -920,9 +920,9 @@ function m.resolvePathPlaceholders(path)
                 return addonsPath
             end
             local client = require("client")
-            local storagePath = fs.path(client.getOption("storagePath"))
+            local storagePath = client.getOption("storagePath")
             if storagePath then
-                addonsPath = (storagePath / "addonManager/addons"):string()
+                addonsPath = (fs.path(storagePath) / "addonManager" / "addons"):string()
             else
                 -- Common path across OSes
                 local dataPath = "User/globalStorage/sumneko.lua/addonManager/addons"

--- a/script/files.lua
+++ b/script/files.lua
@@ -919,10 +919,10 @@ function m.resolvePathPlaceholders(path)
             if addonsPath then
                 return addonsPath
             end
-            local client = require 'client'
-            local storagePath = client.getOption('storagePath')
+            local client = require("client")
+            local storagePath = fs.path(client.getOption("storagePath"))
             if storagePath then
-                addonsPath = storagePath .. "/addonManager/addons"
+                addonsPath = (storagePath / "addonManager/addons"):string()
             else
                 -- Common path across OSes
                 local dataPath = "User/globalStorage/sumneko.lua/addonManager/addons"


### PR DESCRIPTION
I am not sure if this is 100% necessary in order to fix https://github.com/LuaLS/vscode-lua/issues/154… but it should help add more safety, should VS Code choose to provide or not provide a trailing slash for the storage path.

Related client PR: https://github.com/LuaLS/vscode-lua/pull/156