### PR TITLE
[Add] `enum`现在允许在快速修复中导入.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ## Unreleased
 <!-- Add all new changes here. They will be moved under a version at release -->
 * `FIX` A regression related to type narrow and generic param introduced since `v3.10.1`
+* `New` Support importing `enum` through class name suffix matching in quick fixes, allowing the import of `enum` from `table.table.enum; return table`.
 
 ## 3.11.1
 `2024-10-9`

--- a/script/core/code-action.lua
+++ b/script/core/code-action.lua
@@ -695,13 +695,13 @@ local function checkMissingRequire(results, uri, start, finish)
     end
 
     local function addRequires(global, endpos)
-        autoreq.check(state, global, endpos, function(moduleFile, _stemname, _targetSource)
+        autoreq.check(state, global, endpos, function (moduleFile, _stemname, _targetSource, fullKeyPath)
             local visiblePaths = rpath.getVisiblePath(uri, furi.decode(moduleFile))
             if not visiblePaths or #visiblePaths == 0 then return end
 
             for _, target in ipairs(findRequireTargets(visiblePaths)) do
                 results[#results+1] = {
-                    title = lang.script('ACTION_AUTOREQUIRE', target, global),
+                    title = lang.script('ACTION_AUTOREQUIRE', target .. (fullKeyPath or ''), global),
                     kind = 'refactor.rewrite',
                     command = {
                         title     = 'autoRequire',
@@ -711,7 +711,8 @@ local function checkMissingRequire(results, uri, start, finish)
                                 uri         = guide.getUri(state.ast),
                                 target      = moduleFile,
                                 name        = global,
-                                requireName = target
+                                requireName = target,
+                                fullKeyPath = fullKeyPath,
                             },
                         },
                     }

--- a/script/core/command/autoRequire.lua
+++ b/script/core/command/autoRequire.lua
@@ -101,7 +101,7 @@ local function askAutoRequire(uri, visiblePaths)
     return nameMap[result]
 end
 
-local function applyAutoRequire(uri, row, name, result, fmt)
+local function applyAutoRequire(uri, row, name, result, fmt, fullKeyPath)
     local quotedResult = ('%q'):format(result)
     if fmt.quot == "'" then
         quotedResult = ([['%s']]):format(quotedResult:sub(2, -2)
@@ -119,7 +119,7 @@ local function applyAutoRequire(uri, row, name, result, fmt)
     if fmt.col and fmt.col > #text then
         sp = (' '):rep(fmt.col - #text - 1)
     end
-    text = ('local %s%s= require%s\n'):format(name, sp, quotedResult)
+    text = ('local %s%s= require%s%s\n'):format(name, sp, quotedResult, fullKeyPath)
     client.editText(uri, {
         {
             start  = guide.positionOf(row, 0),
@@ -159,6 +159,6 @@ return function (data)
 
     local offset, fmt = findInsertRow(uri)
     if offset and fmt then
-        applyAutoRequire(uri, offset, name, requireName, fmt)
+        applyAutoRequire(uri, offset, name, requireName, fmt, data.fullKeyPath or '')
     end
 end


### PR DESCRIPTION
例如:
键入`EditorAttrKey`会提示导入`local EditorAttrKey = require("schema").EditorAttrKey`
会匹配命名吻合键入内容的枚举类, 支持`xxx.EditorAttrKey`形式