### PR TITLE
Fix table array infer

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 <!-- Add all new changes here. They will be moved under a version at release -->
+* `FIX` Using variables to retrieve array elements always prompts the first element type
 
 ## 3.12.0
 `2024-10-30`

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 <!-- Add all new changes here. They will be moved under a version at release -->
-* `FIX` Using variables to retrieve array elements always prompts the first element type
+* `NEW` Setting: `Lua.type.inferTableSize`: A Small Table array can be infered
 
 ## 3.12.0
 `2024-10-30`

--- a/script/config/template.lua
+++ b/script/config/template.lua
@@ -403,6 +403,7 @@ local template = {
     ['Lua.type.weakNilCheck']               = Type.Boolean >> false,
     ['Lua.type.inferParamType']             = Type.Boolean >> false,
     ['Lua.type.checkTableShape']            = Type.Boolean >> false,
+    ['Lua.type.inferTableSize']             = Type.Integer >> 10,
     ['Lua.doc.privateName']                 = Type.Array(Type.String),
     ['Lua.doc.protectedName']               = Type.Array(Type.String),
     ['Lua.doc.packageName']                 = Type.Array(Type.String),

--- a/script/vm/type.lua
+++ b/script/vm/type.lua
@@ -668,8 +668,6 @@ function vm.getTableValue(uri, tnode, knode, inversion)
                             result:merge(vm.compileNode(field.value))
                         end
                     end
-                elseif field.tindex and field.tindex > N then
-                    fprint("field.tindex = %s", field.tindex)
                 end
                 if field.type == 'varargs' then
                     result:merge(vm.compileNode(field))

--- a/script/vm/type.lua
+++ b/script/vm/type.lua
@@ -656,8 +656,7 @@ function vm.getTableValue(uri, tnode, knode, inversion)
                     end
                 end
                 if  field.type == 'tableexp'
-                and field.value
-                and field.tindex == 1 then
+                and field.value then
                     if inversion then
                         if vm.isSubType(uri, 'integer', knode) then
                             result:merge(vm.compileNode(field.value))

--- a/script/vm/type.lua
+++ b/script/vm/type.lua
@@ -655,10 +655,10 @@ function vm.getTableValue(uri, tnode, knode, inversion)
                         end
                     end
                 end
-                local N = config.get(uri, "Lua.type.inferTableSize")
+                local inferSize = config.get(uri, "Lua.type.inferTableSize")
                 if  field.type == 'tableexp'
                 and field.value
-                and field.tindex <= N then
+                and field.tindex <= inferSize then
                     if inversion then
                         if vm.isSubType(uri, 'integer', knode) then
                             result:merge(vm.compileNode(field.value))

--- a/script/vm/type.lua
+++ b/script/vm/type.lua
@@ -615,6 +615,7 @@ end
 ---@return vm.node?
 function vm.getTableValue(uri, tnode, knode, inversion)
     local result = vm.createNode()
+    local inferSize = config.get(uri, "Lua.type.inferTableSize")
     for tn in tnode:eachObject() do
         if tn.type == 'doc.type.table' then
             for _, field in ipairs(tn.fields) do
@@ -655,7 +656,6 @@ function vm.getTableValue(uri, tnode, knode, inversion)
                         end
                     end
                 end
-                local inferSize = config.get(uri, "Lua.type.inferTableSize")
                 if  field.type == 'tableexp'
                 and field.value
                 and field.tindex <= inferSize then

--- a/script/vm/type.lua
+++ b/script/vm/type.lua
@@ -655,8 +655,10 @@ function vm.getTableValue(uri, tnode, knode, inversion)
                         end
                     end
                 end
+                local N = config.get(uri, "Lua.type.inferTableSize")
                 if  field.type == 'tableexp'
-                and field.value then
+                and field.value
+                and field.tindex <= N then
                     if inversion then
                         if vm.isSubType(uri, 'integer', knode) then
                             result:merge(vm.compileNode(field.value))
@@ -666,6 +668,8 @@ function vm.getTableValue(uri, tnode, knode, inversion)
                             result:merge(vm.compileNode(field.value))
                         end
                     end
+                elseif field.tindex and field.tindex > N then
+                    fprint("field.tindex = %s", field.tindex)
                 end
                 if field.type == 'varargs' then
                     result:merge(vm.compileNode(field))


### PR DESCRIPTION
```lua
local t1 = {
    [1] = {
        x = 1
    },
    [2] = {
        x = "test"
    }
}

local t2 = {
    {
        x = 1
    },
    {
        x = "test"
    }
}

local idx = 2
local a = t1[idx]
local b = t2[idx]
```
让我们键入以上的代码，我认为t1和t2两个数组的结果是一样的，但是结果是变量a和变量b的提示并不一样。
变量a给我的代码提示是我能够接受的，
![image](https://github.com/user-attachments/assets/9f824e7e-9c95-44fa-9ce3-75a76d7d99a1)
但是b给我的代码提示是错误的，始终把`local b = t2[idx]`等价解析为`local b = t2[1]`，这并不完全正确，
![image](https://github.com/user-attachments/assets/6d3ac38b-21e5-4ca6-9ba3-d4aece04cf05)
通过阅读源码，我并不知道为什么针对tableexp类型还要加上`field.tindex == 1`这样的判断，但将其去除后代码提示就正确了。
![image](https://github.com/user-attachments/assets/635a951c-2221-4c1f-ba95-7141512f745f)