### PR TITLE
Added support to build in Linux RISCV64.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,7 @@ jobs:
           - { os: ubuntu-22.04,   target: linux,   platform: linux-x64,   container: 'alpine:latest', libc: musl }
           - { os: ubuntu-20.04,   target: linux,   platform: linux-x64    }
           - { os: ubuntu-20.04,   target: linux,   platform: linux-arm64  }
+          - { os: ubuntu-20.04,   target: linux,   platform: linux-riscv64 }
           - { os: macos-latest,   target: darwin,  platform: darwin-x64   }
           - { os: macos-latest,   target: darwin,  platform: darwin-arm64 }
           - { os: windows-latest, target: windows, platform: win32-ia32   }
@@ -40,6 +41,12 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+
+      - name: Install riscv64-linux-gnu
+        if: ${{ matrix.platform == 'linux-riscv64' && matrix.libc != 'musl' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-riscv64-linux-gnu g++-riscv64-linux-gnu
 
       - name: Prepare container for musl
         if: ${{ matrix.target == 'linux' && matrix.libc == 'musl' }}

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 <!-- Add all new changes here. They will be moved under a version at release -->
+* NEW Support for Linux RISCV64 builds.
 
 ## 3.12.0
 `2024-10-30`

--- a/make/detect_platform.lua
+++ b/make/detect_platform.lua
@@ -25,6 +25,8 @@ elseif platform.os == 'linux' then
     elseif lm.platform == "linux-x64" then
     elseif lm.platform == "linux-arm64" then
         lm.cc = 'aarch64-linux-gnu-gcc'
+    elseif lm.platform == "linux-riscv64" then
+        lm.cc = 'riscv64-linux-gnu-gcc'
     else
         error "unknown platform"
     end
@@ -49,6 +51,7 @@ local ARCH <const> = {
     x86_64 = 'x64',
     i686 = 'ia32',
     arm64 = 'arm64',
+    riscv64 = 'riscv64'
 }
 
 local function detectArch()


### PR DESCRIPTION
Hi lua_ls team!

I recently manually built the server in my RISCV64 Ubuntu 24.10 Linux machine and so far it is working really well for me here. 

It would be great that we would have riscv64 builds so things like mason.nvim work out of the box.

I just added some logic for the platform detection to work with riscv64 and changed the CH actions build script to install the cross compiler and toolchain for RISCV64, pretty much identical to the ARM64 steps.

Here is a small demo video:

[Lua Demo.webm](https://github.com/user-attachments/assets/5354f496-3fda-41b6-aa8f-4ab12375e77c)


