### PR TITLE
fix: improve type narrow with literal alias param during completion and signature help

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 <!-- Add all new changes here. They will be moved under a version at release -->
+* `FIX` Improve type narrow with **literal alias type** during completion and signature help
 
 ## 3.12.0
 `2024-10-30`

--- a/script/core/signature.lua
+++ b/script/core/signature.lua
@@ -114,7 +114,13 @@ local function isEventNotMatch(call, src)
     end
     local eventLiteral = event.extends.types[1] and guide.getLiteral(event.extends.types[1])
     if eventLiteral == nil then
-        return false
+        -- extra checking when function param is not pure literal
+        -- eg: it maybe an alias type with literal values
+        local eventMap = vm.getLiterals(event.extends.types[1])
+        if not eventMap then
+            return false
+        end
+        return not eventMap[literal]
     end
     return eventLiteral ~= literal
 end

--- a/script/vm/compiler.lua
+++ b/script/vm/compiler.lua
@@ -962,6 +962,26 @@ local function compileCallArgNode(arg, call, callNode, fixIndex, myIndex)
     local function dealDocFunc(n)
         local myEvent
         if n.args[eventIndex] then
+            if eventMap and myIndex > eventIndex then
+                -- if call param has literal types, then also check if function def param has literal types
+                -- 1. has no literal values => not enough info, thus allowed by default
+                -- 2. has literal values and >= 1 matches call param's literal types => allowed
+                -- 3. has literal values but none matches call param's literal types => filtered
+                local myEventMap = vm.getLiterals(n.args[eventIndex])
+                if myEventMap then
+                    local found = false
+                    for k in pairs(eventMap) do
+                        if myEventMap[k] then
+                            -- there is a matching literal
+                            found = true
+                            break
+                        end
+                    end
+                    if not found then
+                        return
+                    end
+                end
+            end
             local argNode = vm.compileNode(n.args[eventIndex])
             myEvent = argNode:get(1)
         end

--- a/test/completion/common.lua
+++ b/test/completion/common.lua
@@ -3139,6 +3139,44 @@ emit.on(emit, 'won', <??>)
 }
 
 TEST [[
+--- @alias event.AAA "AAA"
+--- @alias event.BBB "BBB"
+
+--- @class Emit
+--- @field on fun(self: Emit, eventName: string, cb: function)
+--- @field on fun(self: Emit, eventName: event.AAA, cb: fun(i: integer))
+--- @field on fun(self: Emit, eventName: event.BBB, cb: fun(s: string))
+local emit = {}
+
+emit:on('AAA', <??>)
+]]
+{
+    [1] = {
+        label    = 'fun(i: integer)',
+        kind     = define.CompletionItemKind.Function,
+    }
+}
+
+TEST [[
+--- @alias event.AAA "AAA"
+--- @alias event.BBB "BBB"
+
+--- @class Emit
+--- @field on fun(self: Emit, eventName: string, cb: function)
+--- @field on fun(self: Emit, eventName: event.AAA, cb: fun(i: integer))
+--- @field on fun(self: Emit, eventName: event.BBB, cb: fun(s: string))
+local emit = {}
+
+emit:on('BBB', <??>)
+]]
+{
+    [1] = {
+        label    = 'fun(s: string)',
+        kind     = define.CompletionItemKind.Function,
+    }
+}
+
+TEST [[
 local function f()
     local inferCache
     in<??>

--- a/test/signature/init.lua
+++ b/test/signature/init.lua
@@ -373,6 +373,40 @@ t:event("onTimer", <??>)
 '(method) (ev: "onTimer", <!t: integer!>)',
 }
 
+TEST [[
+---@alias event.onChat "onChat"
+---@alias event.onTimer "onTimer"
+
+---@class A
+---@field event fun(self: self, ev: event.onChat, c: string)
+---@field event fun(self: self, ev: event.onTimer, t: integer)
+
+---@type A
+local t
+
+t:event("onChat", <??>)
+]]
+{
+'(method) (ev: "onChat", <!c: string!>)',
+}
+
+TEST [[
+---@alias event.onChat "onChat"
+---@alias event.onTimer "onTimer"
+
+---@class A
+---@field event fun(self: self, ev: event.onChat, c: string)
+---@field event fun(self: self, ev: event.onTimer, t: integer)
+
+---@type A
+local t
+
+t:event("onTimer", <??>)
+]]
+{
+'(method) (ev: "onTimer", <!t: integer!>)',
+}
+
 local config = require 'config'
 config.set(nil, "Lua.type.inferParamType", true)
 


### PR DESCRIPTION
This supports type narrow during **completion** and **signature help** when function params are using `@alias` with literal values, as requested here: https://github.com/LuaLS/lua-language-server/issues/1456#issuecomment-2439765409

Example use case:
```lua
---@alias events.AAA
---| "AAA" # description to AAA
---@alias events.BBB
---| "BBB" # description to BBB

---@class Emitter
---@field on fun(self: self, event: events.AAA,  cb: fun(a: integer))
---@field on fun(self: self, event: events.BBB, cb: fun(b: string))
local Emitter = {}

Emitter:on('BBB', <??>) --< trigger completion will suggest `fun(b: string)`, instead of showing both
```

## 中文版

上述 issue comment 作者想用 `@alias` 來定義 event name，因為這樣可以對 enum value 加 description，但發現用 alias 後做 completion 時無法做 type narrow。
這個 PR 是想在做 completion 和 signature help 時，增加檢查 function param 對應的 literal values 是否符合 event name
- 如果 function param 沒有 literal value => 無從判斷，維持原狀不會 narrow
- 有 literal values，並且至少 1個跟 call param literal value 是 match => 允許
- 有 literal values，但無一跟 call param literal value 是 match => 過濾掉