### PR TITLE
feat: infer function param when the function is passed as call arg

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,14 @@
 * `FIX` Improve type narrow with **literal alias type** during completion and signature help
 * `NEW` Setting: `Lua.type.inferTableSize`: A Small Table array can be infered
 * `NEW` Add custom repository support for addonManager. New configuration setting: `Lua.addonManager.repositoryBranch` and `Lua.addonManager.repositoryPath`
+* `NEW` Infer function parameter types when the function is used as an callback argument and that argument has a `fun()` annotation. Enable with `Lua.type.inferParamType` setting. [#2695](https://github.com/LuaLS/lua-language-server/pull/2695)
+  ```lua
+  ---@param callback fun(a: integer)
+  function register(callback) end
+
+  local function callback(a) end  --> a: integer
+  register(callback)
+  ```
 
 ## 3.12.0
 `2024-10-30`

--- a/test/type_inference/common.lua
+++ b/test/type_inference/common.lua
@@ -1135,6 +1135,80 @@ xpcall(work, debug.traceback, function (<?value?>)
 end)
 ]]
 
+config.set(nil, "Lua.type.inferParamType", true)
+
+TEST 'Class' [[
+---@class Class
+
+---@param callback fun(value: Class)
+function work(callback) end
+
+local function cb(<?value?>) end
+work(cb)
+]]
+
+TEST 'any' [[
+---@class Class
+
+---@param callback fun(value: Class)
+function work(callback) end
+
+---@param value any
+local function cb(<?value?>) end
+work(cb)
+]]
+
+TEST 'any' [[
+---@class Class
+
+function work(callback) end
+
+local function cb(<?value?>) end
+work(cb)
+]]
+
+TEST 'string' [[
+---@class Class
+
+function work(callback) end
+
+---@param value string
+local function cb(<?value?>) end
+work(cb)
+]]
+
+
+TEST 'Parent' [[
+---@class Parent
+local Parent
+
+---@generic T
+---@param self T
+---@param callback fun(self: T)
+function Parent:work(callback) end
+
+local function cb(<?self?>) end
+Parent:work(cb)
+]]
+
+TEST 'Child' [[
+---@class Parent
+local Parent
+
+---@generic T
+---@param self T
+---@param callback fun(self: T)
+function Parent:work(callback) end
+
+---@class Child: Parent
+local Child
+
+local function cb(<?self?>) end
+Child:work(cb)
+]]
+
+config.set(nil, "Lua.type.inferParamType", false)
+
 TEST 'string' [[
 ---@generic T
 ---@param x T


### PR DESCRIPTION
closes #2695 (the feature request by **me**, finally I have the knowledge to implement myself 🙂 )

- This supports inferring function param type when the **local function** is used as **call argument**, and that the argument has a `fun()` annotation.
- This is actually an improvement to the existing `Lua.type.inferParamType` logic, so this feature is only enabled when this config is set to `true`.

### Example Use Case
```lua
---@param callback fun(a: integer)
function register(callback) end

local function callback(a) end  --> a: integer
register(callback)
```
which is similar to existing infer behavior with function literal:
```lua
register(function (a)  --> a: integer
end)
```

---

## 中文版

- 具體應用例子見上邊
- 在效果上來說跟現有的 function literal infer param type 基本相同，只不過是應用到 **local function** 的 param 上
- 這個算是對現有 `Lua.type.inferParamType` 功能的延伸，所以要開啟這個 config 才會生效

### 實現思路
- 在 infer 1個未被 annotate 的 local function param type 時
如果這個 function variable 是在某次 call 中作為 arg
應該是可以嘗試用該 arg 位置的 `doc.type.function` (如有) 來進一步 infer
- 而在早些時間我研究這裡的 completion 問題時: https://github.com/LuaLS/lua-language-server/issues/1456#issuecomment-2451400831
我找到原來有1個 `vm.compileCallArg()` 可以 compile 某個 call 行為的指定 index argument type
- 那麼對於有使用在 call arg 的 function variable 來說
  - 首先我利用上述 function 來模擬觸發1次 completion => 獲取在 `cbIndex` 的 arg infer type
  - 如果這裡的 infer type 帶有 `doc.type.function`，則再利用這 function 的 `args[aindex]` (當前 local function param index) 的 type 來做 infer
  - 如果找到 infer type 的話就 merge 入當前 param type