### PR TITLE
fix: add missing `errs ~= nil` checks to script/vm/type checkTableShape

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 <!-- Add all new changes here. They will be moved under a version at release -->
+* `FIX` Add missing `errs ~= nil` checks to script/vm/type checkTableShape
 
 ## 3.13.1
 `2024-11-13`

--- a/script/vm/type.lua
+++ b/script/vm/type.lua
@@ -321,9 +321,11 @@ local function checkTableShape(parent, child, uri, mark, errs)
             if myKeys[key] then
                 ok = vm.isSubType(uri, myKeys[key], nodeField, mark, errs)
                 if ok == false then
-                    errs[#errs+1] = 'TYPE_ERROR_PARENT_ALL_DISMATCH' -- error display can be greatly improved
-                    errs[#errs+1] = myKeys[key]
-                    errs[#errs+1] = nodeField
+                    if errs then
+                        errs[#errs+1] = 'TYPE_ERROR_PARENT_ALL_DISMATCH' -- error display can be greatly improved
+                        errs[#errs+1] = myKeys[key]
+                        errs[#errs+1] = nodeField
+                    end
                     failedCheck = true
                 end
             elseif not nodeField:isNullable() then
@@ -337,7 +339,7 @@ local function checkTableShape(parent, child, uri, mark, errs)
         end
         ::continue::
     end
-    if #missedKeys > 0 then
+    if errs and #missedKeys > 0 then
         errs[#errs+1] = 'DIAG_MISSING_FIELDS'
         errs[#errs+1] = parent
         errs[#errs+1] = table.concat(missedKeys, ', ')


### PR DESCRIPTION
fix that

```shell
[Error - 12:44:58 PM] Request textDocument/semanticTokens/range failed.
  Message: [12:44:56.481][error][#0:script/vm/type.lua:341]: script/vm/type.lua:341: attempt to get length of a nil value (local 'errs')
stack traceback:
	script/vm/type.lua:341: in function <script/vm/type.lua:287>
	(...tail calls...)
	script/vm/type.lua:461: in function 'vm.vm.isSubType'
	script/vm/type.lua:372: in function 'vm.vm.isSubType'
	script/vm/type.lua:785: in function 'vm.vm.canCastType'
	script/vm/function.lua:349: in upvalue 'isAllParamMatched'
	script/vm/function.lua:363: in upvalue 'calcFunctionMatchScore'
	script/vm/function.lua:400: in function 'vm.vm.getExactMatchedFunctions'
	script/vm/compiler.lua:611: in upvalue 'matchCall'
	script/vm/compiler.lua:2278: in function 'vm.vm.compileNode'
	script/vm/infer.lua:272: in function 'vm.vm.getInfer'
	script/core/semantic-tokens.lua:140: in function <script/core/semantic-tokens.lua:114>
	(...tail calls...)
	script/core/semantic-tokens.lua:892: in local 'callback'
	script/parser/guide.lua:719: in function 'parser.guide.eachSourceBetween'
	script/core/semantic-tokens.lua:887: in function 'core.semantic-tokens'
	script/provider/provider.lua:1124: in function <script/provider/provider.lua:1112>
	[C]: in function 'xpcall'
	script/proto/proto.lua:202: in function <script/proto/proto.lua:177>
```
	