### PR TITLE
Fix missing-fields diagnostic not warning about missing inherited fields

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 <!-- Add all new changes here. They will be moved under a version at release -->
+* `FIX` missing-fields diagnostic now warns about missing inherited fields
 
 ## 3.13.2
 `2024-11-21`

--- a/script/core/diagnostics/missing-fields.lua
+++ b/script/core/diagnostics/missing-fields.lua
@@ -41,7 +41,8 @@ return function (uri, callback)
         for className, samedefs in pairs(sortedDefs) do
             local missedKeys = {}
             for _, def in ipairs(samedefs) do
-                if not def.fields or #def.fields == 0 then
+                local fields = vm.getFields(def)
+                if #fields == 0 then
                     goto continue
                 end
 
@@ -55,7 +56,7 @@ return function (uri, callback)
                     end
                 end
 
-                for _, field in ipairs(def.fields) do
+                for _, field in ipairs(fields) do
                     if  not field.optional
                     and not vm.compileNode(field):isNullable() then
                         local key = vm.getKeyName(field)

--- a/test/diagnostics/missing-fields.lua
+++ b/test/diagnostics/missing-fields.lua
@@ -353,3 +353,113 @@ TEST[[
 ---@type A
 local t = <!{x = 1}!>
 ]]
+
+-- Inheritance
+
+TEST[[
+---@class A
+---@field x number
+
+---@class B: A
+
+---@type B
+local t = <!{}!>
+]]
+
+TEST[[
+---@class A
+---@field x number
+---@field y number
+
+---@class B: A
+
+---@type B
+local t = <!{y = 1}!>
+]]
+
+TEST[[
+---@class A
+---@field x number
+
+---@class B: A
+---@field y number
+
+---@type B
+local t = <!{y = 1}!>
+]]
+
+-- Inheritance + optional
+
+TEST[[
+---@class A
+---@field x? number
+
+---@class B: A
+
+---@type B
+local t = {}
+]]
+
+TEST[[
+---@class A
+---@field x? number
+---@field y number
+
+---@class B: A
+
+---@type B
+local t = {y = 1}
+]]
+
+TEST[[
+---@class A
+---@field x? number
+
+---@class B: A
+---@field y number
+
+---@type B
+local t = {y = 1}
+]]
+
+-- Inheritance + function call
+
+TEST[[
+---@class A
+---@field x number
+
+---@class B: A
+
+---@param b B
+local function f(b) end
+
+f <!{}!>
+]]
+
+TEST[[
+---@class A
+---@field x number
+---@field y number
+
+---@class B: A
+
+---@param b B
+local function f(b) end
+
+f <!{y = 1}!>
+]]
+
+TEST[[
+---@class A
+---@field x number
+
+---@class B: A
+---@field y number
+
+---@param b B
+local function f(b) end
+
+f <!{y = 1}!>
+]]
+
+--


### PR DESCRIPTION
Should close #2337, close #2598, close #2740, close #2966 