### PR TITLE
add option `Lua.hint.awaitPropagate` to propagate `---@async`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 <!-- Add all new changes here. They will be moved under a version at release -->
+* `NEW` Setting: `Lua.hint.awaitPropagate`: When enabled, --@async propagates to the caller.
 
 ## 3.13.3
 * `CHG` Update Love2d version

--- a/locale/en-us/setting.lua
+++ b/locale/en-us/setting.lua
@@ -256,6 +256,9 @@ config.hint.arrayIndex.Disable           =
 'Disable hints of array index.'
 config.hint.await                        =
 'If the called function is marked `---@async`, prompt `await` at the call.'
+config.hint.awaitPropagate               =
+'Enable the propagation of `await`. When a function calls a function marked `---@async`,\z
+it will be automatically marked as `---@async`.'
 config.hint.semicolon                    =
 'If there is no semicolon at the end of the statement, display a virtual semicolon.'
 config.hint.semicolon.All                =

--- a/locale/ja-jp/setting.lua
+++ b/locale/ja-jp/setting.lua
@@ -256,6 +256,9 @@ config.hint.arrayIndex.Disable           = -- TODO: need translate!
 'Disable hints of array index.'
 config.hint.await                        = -- TODO: need translate!
 'If the called function is marked `---@async`, prompt `await` at the call.'
+config.hint.awaitPropagate               = -- TODO: need translate!
+'Enable the propagation of `await`. When a function calls a function marked `---@async`,\z
+it will be automatically marked as `---@async`.'
 config.hint.semicolon                    = -- TODO: need translate!
 'If there is no semicolon at the end of the statement, display a virtual semicolon.'
 config.hint.semicolon.All                = -- TODO: need translate!

--- a/locale/pt-br/setting.lua
+++ b/locale/pt-br/setting.lua
@@ -256,6 +256,9 @@ config.hint.arrayIndex.Disable           = -- TODO: need translate!
 'Disable hints of array index.'
 config.hint.await                        = -- TODO: need translate!
 'If the called function is marked `---@async`, prompt `await` at the call.'
+config.hint.awaitPropagate               = -- TODO: need translate!
+'Enable the propagation of `await`. When a function calls a function marked `---@async`,\z
+it will be automatically marked as `---@async`.'
 config.hint.semicolon                    = -- TODO: need translate!
 'If there is no semicolon at the end of the statement, display a virtual semicolon.'
 config.hint.semicolon.All                = -- TODO: need translate!

--- a/locale/zh-cn/setting.lua
+++ b/locale/zh-cn/setting.lua
@@ -255,6 +255,8 @@ config.hint.arrayIndex.Disable           =
 '禁用数组索引提示。'
 config.hint.await                        =
 '如果调用的函数被标记为了 `---@async` ，则在调用处提示 `await` 。'
+config.hint.awaitPropagate               =
+'启用 `await` 的传播, 当一个函数调用了一个`---@async`标记的函数时，会自动标记为`---@async`。'
 config.hint.semicolon                    =
 '若语句尾部没有分号，则显示虚拟分号。'
 config.hint.semicolon.All                =

--- a/locale/zh-tw/setting.lua
+++ b/locale/zh-tw/setting.lua
@@ -255,6 +255,8 @@ config.hint.arrayIndex.Disable           =
 '停用陣列索引提示。'
 config.hint.await                        =
 '如果呼叫的函數被標記為了 `---@async`，則在呼叫處提示 `await`。'
+config.hint.awaitPropagate               =
+'啟用 `await` 的傳播，當一個函數呼叫了一個 `---@async` 標記的函數時，會自動標記為 `---@async`。'
 config.hint.semicolon                    =
 '若陳述式尾部沒有分號，則顯示虛擬分號。'
 config.hint.semicolon.All                =

--- a/script/config/template.lua
+++ b/script/config/template.lua
@@ -369,6 +369,7 @@ local template = {
                                                 'Disable',
                                             },
     ['Lua.hint.await']                      = Type.Boolean >> true,
+    ['Lua.hint.awaitPropagate']             = Type.Boolean >> false,
     ['Lua.hint.arrayIndex']                 = Type.String >> 'Auto' << {
                                                 'Enable',
                                                 'Auto',


### PR DESCRIPTION
This option is disabled by default.
When disabled, it has no impact on performance.
When enabled, due to its upward propagation characteristics,
     it may render some await-in-sync diagnostics ineffective,
     but not all of them.
See Discussion #2981 .