### PR TITLE
fix: incorrect infer of function array annotation on tables

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 <!-- Add all new changes here. They will be moved under a version at release -->
+* `FIX` Incorrect infer for function array annotation on tables [#2367](https://github.com/LuaLS/lua-language-server/issues/2367)
 
 ## 3.13.4
 `2024-12-13`

--- a/script/parser/guide.lua
+++ b/script/parser/guide.lua
@@ -940,6 +940,7 @@ local assignTypeMap = {
     ['setindex']          = true,
     ['tablefield']        = true,
     ['tableindex']        = true,
+    ['tableexp']          = true,
     ['label']             = true,
     ['doc.class']         = true,
     ['doc.alias']         = true,

--- a/script/vm/compiler.lua
+++ b/script/vm/compiler.lua
@@ -1671,7 +1671,9 @@ local compilerSwitch = util.switch()
                 vm.compileByParentNode(source.node, key, function (src)
                     if src.type == 'doc.field'
                     or src.type == 'doc.type.field'
-                    or src.type == 'doc.type.name' then
+                    or src.type == 'doc.type.name'
+                    or src.type == 'doc.type.function'
+                    then
                         hasMarkDoc = true
                         vm.setNode(source, vm.compileNode(src))
                     end

--- a/test/type_inference/common.lua
+++ b/test/type_inference/common.lua
@@ -3943,6 +3943,34 @@ TEST 'number' [[
 local function f(<?x?>) end
 ]]
 
+TEST 'number' [[
+---@type fun(x:number)[]
+local t = {
+    function (<?x?>) end,
+}
+]]
+
+TEST 'number' [[
+---@type fun(x:number)[]
+local t = {
+    [1] = function (<?x?>) end,
+}
+]]
+
+TEST 'number' [[
+---@type {[integer]: fun(x:number)}
+local t = {
+    function (<?x?>) end,
+}
+]]
+
+TEST 'number' [[
+---@type {[integer]: fun(x:number)}
+local t = {
+    [1] = function (<?x?>) end,
+}
+]]
+
 TEST 'boolean' [[
 ---@generic T: string | boolean | table
 ---@param x T


### PR DESCRIPTION
fix #2367

bugfix explanation:
- `{ function() end }` is parsed as `tableexp`
but it is not considered as **assign type**
=> so it is not receiving type infer from `---@type {[integer]: fun()}` annotation
https://github.com/LuaLS/lua-language-server/issues/2367#issuecomment-2310196191
- the `---@type fun()[]` annotation is giving out `doc.type.function` when inferring `tableindex` operation
but is ignored by the current logic
=> so `{ [1] = function () end }` cannot receive type infer
https://github.com/LuaLS/lua-language-server/issues/2367#issuecomment-2538834404