### PR TITLE
Add `serverInfo.version` to `initialize` response

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ## Unreleased
 <!-- Add all new changes here. They will be moved under a version at release -->
 * `FIX` Incorrect infer for function array annotation on tables [#2367](https://github.com/LuaLS/lua-language-server/issues/2367)
+* `CHG` Add server version information to `initialize` response #2996
 
 ## 3.13.4
 `2024-12-13`

--- a/script/provider/provider.lua
+++ b/script/provider/provider.lua
@@ -19,6 +19,7 @@ local furi       = require 'file-uri'
 local inspect    = require 'inspect'
 local guide      = require 'parser.guide'
 local fs         = require 'bee.filesystem'
+local version    = require 'version'
 
 require 'library'
 
@@ -128,6 +129,7 @@ m.register 'initialize' {
             capabilities = cap.getProvider(),
             serverInfo   = {
                 name    = 'sumneko.lua',
+                version = version.getVersion(),
             },
         }
         log.debug('Server init', inspect(response))


### PR DESCRIPTION
This is useful to be able to display the version of the currently attached server. See https://github.com/neovim/neovim/pull/31611 for example.

https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#initializeResult