### PR TITLE
Send the correct `insertTextFormat`

### DIFF
--- a/script/provider/provider.lua
+++ b/script/provider/provider.lua
@@ -661,7 +661,7 @@ m.register 'textDocument/completion' {
                 sortText         = res.sortText or ('%04d'):format(i),
                 filterText       = res.filterText,
                 insertText       = res.insertText,
-                insertTextFormat = 2,
+                insertTextFormat = res.insertTextFormat or 1,
                 commitCharacters = res.commitCharacters,
                 command          = res.command,
                 textEdit         = res.textEdit and {


### PR DESCRIPTION
Per LSP specification, `insertTextFormat` should be `2` for snippets and `1` for plain text. Using `2` unconditionally can make clients behave in unexpected ways. For example, the `nvim-cmp` plugin for Neovim doesn't properly handle the case of completion inside of a snippet when `insertTextFormat` is incorrect.

The code calling into `provider.lua` sets `insertTextFormat` to 2 for all snippets and leaves it nil for other types, so we can reuse that information in `provider.lua` to make sure we send the correct value.

This was previously brought up in #992, but the closing PR didn't resolve the issue directly.