### PR TITLE
Fixed the error that the configuration file pointed to by the `--configpath` option was not read and loaded.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 <!-- Add all new changes here. They will be moved under a version at release -->
+* `FIX` Fixed the error that the configuration file pointed to by the `--configpath` option was not read and loaded.
 
 ## 3.13.5
 `2024-12-20`

--- a/script/cli/doc/init.lua
+++ b/script/cli/doc/init.lua
@@ -193,8 +193,8 @@ function doc.runCLI()
 
     print('root uri = ' .. rootUri)
 
-    --- If '--configpath' is specified, get the folder path of the '.luarc.doc.josn' configuration file (without the file name)
-    --- 如果指定了'--configpath'，则获取`.luarc.doc.josn` 配置文件的文件夹路径(不包含文件名）
+    --- If '--configpath' is specified, get the folder path of the '.luarc.doc.json' configuration file (without the file name)
+    --- 如果指定了'--configpath'，则获取`.luarc.doc.json` 配置文件的文件夹路径(不包含文件名）
     --- This option is passed into the callback function of the initialized method in provide.
     --- 该选项会被传入到`provide`中的`initialized`方法的回调函数中
     local luarcParentUri
@@ -212,7 +212,7 @@ function doc.runCLI()
 
         client:initialize {
             rootUri = rootUri,
-            luarcParentUri = luarcParentUri
+            luarcParentUri = luarcParentUri,
         }
         io.write(lang.script('CLI_DOC_INITING'))
 

--- a/script/cli/doc/init.lua
+++ b/script/cli/doc/init.lua
@@ -41,7 +41,7 @@ local function getPathDocUpdate()
                     return section.DOC
                 end
             end
-    end)
+        end)
     if ok then
         local doc_json_dir = doc_json_path:string():gsub('/doc.json', '')
         return doc_json_dir, doc_path
@@ -131,7 +131,7 @@ local function injectBuildScript()
         },
         {__index = _G}))
     if err or not data then
-       error(err, 0)
+        error(err, 0)
     end
     data()
     return module
@@ -193,6 +193,15 @@ function doc.runCLI()
 
     print('root uri = ' .. rootUri)
 
+    --- If '--configpath' is specified, get the folder path of the '.luarc.doc.josn' configuration file (without the file name)
+    --- 如果指定了'--configpath'，则获取`.luarc.doc.josn` 配置文件的文件夹路径(不包含文件名）
+    --- This option is passed into the callback function of the initialized method in provide.
+    --- 该选项会被传入到`provide`中的`initialized`方法的回调函数中
+    local luarcParentUri
+    if CONFIGPATH then
+        luarcParentUri = furi.encode(fs.absolute(fs.path(CONFIGPATH)):parent_path():string())
+    end
+
     util.enableCloseFunction()
 
     local lastClock = os.clock()
@@ -203,6 +212,7 @@ function doc.runCLI()
 
         client:initialize {
             rootUri = rootUri,
+            luarcParentUri = luarcParentUri
         }
         io.write(lang.script('CLI_DOC_INITING'))
 
@@ -222,11 +232,11 @@ function doc.runCLI()
             if os.clock() - lastClock > 0.2 then
                 lastClock = os.clock()
                 local output = '\x0D'
-                            .. ('>'):rep(math.ceil(i / max * 20))
-                            .. ('='):rep(20 - math.ceil(i / max * 20))
-                            .. ' '
-                            .. ('0'):rep(#tostring(max) - #tostring(i))
-                            .. tostring(i) .. '/' .. tostring(max)
+                    .. ('>'):rep(math.ceil(i / max * 20))
+                    .. ('='):rep(20 - math.ceil(i / max * 20))
+                    .. ' '
+                    .. ('0'):rep(#tostring(max) - #tostring(i))
+                    .. tostring(i) .. '/' .. tostring(max)
                 io.write(output)
             end
         end)

--- a/script/lclient.lua
+++ b/script/lclient.lua
@@ -77,7 +77,7 @@ local defaultClientOptions = {
                         valueSet = {
                             define.DiagnosticTag.Unnecessary,
                             define.DiagnosticTag.Deprecated,
-                         },
+                        },
                     },
                 },
             },
@@ -92,7 +92,7 @@ local defaultClientOptions = {
 function mt:initialize(params)
     local initParams = util.tableMerge(params or {}, defaultClientOptions)
     self:awaitRequest('initialize', initParams)
-    self:notify('initialized')
+    self:notify('initialized', initParams)
 end
 
 function mt:reportHangs()

--- a/script/provider/provider.lua
+++ b/script/provider/provider.lua
@@ -141,7 +141,7 @@ m.register 'initialized'{
     ---@async
     function (_params)
         local _ <close> = progress.create(workspace.getFirstScope().uri, lang.script.WINDOW_INITIALIZING, 0.5)
-        m.updateConfig()
+        m.updateConfig((_params or {}).luarcParentUri)
         local registrations = {}
 
         if client.getAbility 'workspace.didChangeConfiguration.dynamicRegistration' then

--- a/script/provider/provider.lua
+++ b/script/provider/provider.lua
@@ -141,7 +141,8 @@ m.register 'initialized'{
     ---@async
     function (_params)
         local _ <close> = progress.create(workspace.getFirstScope().uri, lang.script.WINDOW_INITIALIZING, 0.5)
-        m.updateConfig((_params or {}).luarcParentUri)
+        --- 传递`.luarc.doc.json`文件所在的文件夹路径
+        m.updateConfig(_params and _params.luarcParentUri)
         local registrations = {}
 
         if client.getAbility 'workspace.didChangeConfiguration.dynamicRegistration' then

--- a/script/provider/provider.lua
+++ b/script/provider/provider.lua
@@ -139,10 +139,10 @@ m.register 'initialize' {
 
 m.register 'initialized'{
     ---@async
-    function (_params)
+    function (params)
         local _ <close> = progress.create(workspace.getFirstScope().uri, lang.script.WINDOW_INITIALIZING, 0.5)
         --- 传递`.luarc.doc.json`文件所在的文件夹路径
-        m.updateConfig(_params and _params.luarcParentUri)
+        m.updateConfig(params and params.luarcParentUri)
         local registrations = {}
 
         if client.getAbility 'workspace.didChangeConfiguration.dynamicRegistration' then


### PR DESCRIPTION
fixes #3008, fixes #2997
# Info
Follow-up on my issue #3008 .Screenshots of some of the effects can also be found in the issue.
This commit is intended to fix a bug where exporting a document via the command line could not read the configuration file specified with the '--configpath' option.

# ENV

## `.luarc.json` file 
from: [#2997](https://github.com/LuaLS/lua-language-server/issues/2997#issue-2749438160)
[.luarc.doc.json](https://github.com/user-attachments/files/18261936/default.luarc.doc.json)

## command

``` shell
./bin/lua-language-server.exe --configpath ./.luarc.doc.json --doc ./test/main.lua --doc_out_path ./test/
```
## test lua file

``` lua
M = {}
```
# result
## output json doc file:
[doc.json](https://github.com/user-attachments/files/18261929/doc.json)

## Add the terminal output of the print statement
``` shell
root uri        file:///e%3A/luals/old/test/main.lua
Config All Path:        E:/luals/old/.luarc.doc.json
configName:     .luarc.doc.json
parent: E:/luals/old
------
uri type:       string  file:///e%3A/luals/old
CONFIGPATH      ./.luarc.doc.json
aaa     .luarc.doc.json

==================
loadLocalConfig Test Begins
folderPath      E:\luals\old
after :         E:\luals\old\.luarc.doc.json
loadLocalConfig Test end
 ================

path:   E:\luals\old\.luarc.doc.json
 buf    string  {
  "$schema": "https://raw.githubusercontent.com/sumneko/vscode-lua/master/setting/schema.json",
  "runtime.version": "Lua 5.1",
  "runtime.builtin": {
    "basic": "disable",
    "bit": "disable",
    "bit32": "disable",
    "builtin": "disable",
    "coroutine": "disable",
    "debug": "disable",
    "ffi": "disable",
    "io": "disable",
    "jit": "disable",
    "math": "disable",
    "os": "disable",
    "package": "disable",
    "string": "disable",
    "table": "disable",
    "table.clear": "disable",
    "table.new": "disable",
    "utf8": "disable"
  }
}
Documentation exported:

test\doc.json
test\doc.md
```
# Postscript

I believe that with the fix of this bug, you can use the document export function, no need to make changes to the source code, and only need the configuration file to filter out the standard libraries in the environment.
If I can help you, then my work is meaningful.