### PR TITLE
Mark function completion items as snippets

### DIFF
--- a/script/core/completion/completion.lua
+++ b/script/core/completion/completion.lua
@@ -1351,6 +1351,7 @@ local function insertEnum(state, pos, src, enums, isInArray, mark)
             description = description,
             kind        = define.CompletionItemKind.Function,
             insertText  = insertText,
+            insertTextFormat = 2,
         }
     elseif src.type == 'doc.enum' then
         ---@cast src parser.object


### PR DESCRIPTION
The PR #3005 assumed that all snippets were setting `insertTextFormat` to 2 and leaving plaintext completions nil, but that was not the case. Function completions need to be marked as snippets too.

fixes #3021