### PR TITLE
Basic `partial` class support

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,20 @@
   ```
 * `NEW` Test CLI: `--name=<testname>` `-n=<testname>`: run specify unit test
 * `FIX` Fixed the error that the configuration file pointed to by the `--configpath` option was not read and loaded.
+* `NEW` `---@class` supports attribute `partial`, which will not check missing inherited fields [#3023](https://github.com/LuaLS/lua-language-server/issues/3023)
+  ```lua
+  ---@class Config
+  ---@field a number
+
+  ---@class (partial) Config.P: Config
+  ---@field b number
+
+  ---@type Config.P[]
+  local cfgs = {}
+  cfgs[1] = { b = 1 } -- no warning
+  cfgs[2] = {}        -- only warns missing `b`
+  ```
+  This enables the previous missing field check behavior before [#2970](https://github.com/LuaLS/lua-language-server/issues/2970)
 
 ## 3.13.5
 `2024-12-20`

--- a/test/diagnostics/missing-fields.lua
+++ b/test/diagnostics/missing-fields.lua
@@ -462,4 +462,38 @@ local function f(b) end
 f <!{y = 1}!>
 ]]
 
+-- partial class
+
+TEST[[
+---@class A
+---@field x number
+
+---@class (partial) B: A
+
+---@type B
+local t = {}
+]]
+
+TEST[[
+---@class A
+---@field x number
+
+---@class (partial) B: A
+---@field y number
+
+---@type B
+local t = <!{}!>
+]]
+
+TEST[[
+---@class A
+---@field x number
+
+---@class (partial) B: A
+---@field y number
+
+---@type B
+local t = {y = 1}
+]]
+
 --


### PR DESCRIPTION
resolves #3023, resolves #2561

---

Since #2970, the partial class "hack" for not checking missing inherited fields no longer works.
This PR brings back this feature by introducing a `partial` attribute for `@class`.
A class marked with `partial` will not check missing inherited fields, just like the original checking behavior.

## Example
```lua
---@class Config
---@field a number

---@class (partial) Config.P: Config
---@field b number

---@type Config.P[]
local cfgs = {}
cfgs[1] = { b = 1 } -- no warning
cfgs[2] = {}        -- only warns missing `b`
```

## 中文版

自 #2970 起，原有的 partial class hack 被封了。
這個 PR 對 `@class` 簡單地引入 `partial` 屬性
=> 帶 `partial` 屬性的 class 在檢查 missing fields 時會忽略 inherited class 的字段，就像之前的 check logic 一樣