### PR TITLE
Improve generic pattern to support optional, union, array. Fixed regression.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,14 +2,14 @@
 
 ## Unreleased
 <!-- Add all new changes here. They will be moved under a version at release -->
-* `CHG` [#3014] Generic pattern now supports definition after capture
+* `CHG` [#3014] Generic pattern now supports definition after capture and optional, union, array
   ```lua
   ---@generic T
-  ---@param t `T`.Cat
-  ---@return T
+  ---@param t `T`.Cat?
+  ---@return T?
   local function f(t) end
 
-  local t = f('Smile') --> t is `Smile.Cat`
+  local t = f('Smile') --> t is `(Smile.Cat)?`
   ```
 * `NEW` Test CLI: `--name=<testname>` `-n=<testname>`: run specify unit test
 * `FIX` Fixed the error that the configuration file pointed to by the `--configpath` option was not read and loaded.

--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@
   ```
 * `NEW` Test CLI: `--name=<testname>` `-n=<testname>`: run specify unit test
 * `FIX` Fixed the error that the configuration file pointed to by the `--configpath` option was not read and loaded.
+* `FIX` Generic return can be optional.
 
 ## 3.13.5
 `2024-12-20`

--- a/script/vm/generic.lua
+++ b/script/vm/generic.lua
@@ -136,6 +136,9 @@ function mt:resolve(uri, args)
             end
         end
     end
+    if protoNode:isOptional() then
+        result:addOptional()
+    end
     return result
 end
 

--- a/test/definition/luadoc.lua
+++ b/test/definition/luadoc.lua
@@ -239,7 +239,7 @@ TEST [[
 AAAA = {};
 
 function AAAA:<!SSDF!>()
-
+    
 end
 
 AAAA.a.<?SSDF?>
@@ -352,7 +352,7 @@ local Foo = {}
 function Foo:bar1() end
 
 ---@generic T
----@param arg1 `T`*
+---@param arg1 `T`*?
 ---@return T
 function Generic(arg1) print(arg1) end
 
@@ -366,7 +366,7 @@ local Foo = {}
 function Foo:<!bar1!>() end
 
 ---@generic T
----@param arg1 `T`*
+---@param arg1 `T`*?
 ---@return T
 function Generic(arg1) print(arg1) end
 
@@ -399,6 +399,34 @@ function Foo:<!bar1!>() end
 function Generic(arg1) print(arg1) end
 
 local v1 = Generic("Foo")
+print(v1.<?bar1?>)
+]]
+
+TEST [[
+---@class n-Foo-2
+local Foo = {}
+function Foo:bar1() end
+
+---@generic T
+---@param arg1 n-`T`-2[]
+---@return T
+function Generic(arg1) print(arg1) end
+
+local v1 = Generic({Foo})
+print(v1.<?bar1?>)
+]]
+
+TEST [[
+---@class n-Foo-2
+local Foo = {}
+function Foo:<!bar1!>() end
+
+---@generic T
+---@param arg1 n-`T`-2[]
+---@return T
+function Generic(arg1) print(arg1) end
+
+local v1 = Generic({"Foo"})
 print(v1.<?bar1?>)
 ]]
 

--- a/test/diagnostics/missing-return.lua
+++ b/test/diagnostics/missing-return.lua
@@ -156,3 +156,21 @@ function F()
 
 end
 ]]
+
+TEST [[
+---@generic T
+---@param t T
+---@return T
+function F(t)
+	return t
+end
+]]
+
+TEST [[
+---@generic T
+---@param t T
+---@return T?
+function F(t)
+
+end
+]]

--- a/test/type_inference/common.lua
+++ b/test/type_inference/common.lua
@@ -359,8 +359,32 @@ end
 local _, _, _, <?b?>, _ = x(nil, true, 1, 'yy')
 ]]
 
+TEST 'nil' [[
+local <?k?>, <?v?> = next()
+local <?k?>, <?v?> = next({})
+]]
+
+TEST 'integer?' [[
+local <?k?>, <?v?> = next({1})
+]]
+
+TEST 'integer?' [[
+local a
+local <?k?>, v = next({a})
+]]
+
+-- probably explicit unknown generic should be unknown
+TEST 'nil' [[
+local a
+local k, <?v?> = next({a})
+]]
+
 TEST 'unknown' [[
-local <?x?> = next()
+---@generic T
+---@param t T?
+---@return T
+local function F(t) end
+local <?x?> = F()
 ]]
 
 TEST 'unknown' [[


### PR DESCRIPTION
I examined the original **generic pattern** code in more detail and realized that it incorrectly handles cases when it cannot parse further. We need to **partially successfully parse**, not cancel it by `return nil`.

- Fixed regression by previous pull request #3015 where `parseCode` was replaced with `parseCodePattern`
```lua
---@param a `TC`#Comment -- ok
---@param a `TC`? -- ok
---@param a `TC`|integer -- ok
---@param a `TC`[] -- ok
```

- Generic pattern now supports **optional**, **union**, **array** and **comment without a space**, like all other types.
The **signs** `<>` are also correctly recognized, but the generics don't support it at all.
```lua
---@param a string#Comment -- ok
---@param a `TCP`2#Comment -- now ok
---@param a `TCP`2? -- now ok
---@param a `TCP`2|integer -- now ok
---@param a `TCP`2[] -- now ok
```

<details>
<summary>My complete test</summary>

```lua
---@param a string#Comment
---@return string
local function new(a) end
local obj = new("Vehicle")

---@generic T
---@param a T#Comment
---@return T
local function new(a) end
local obj = new("Vehicle")

---@generic TC
---@param a `TC`#Comment
---@return TC
local function new(a) end
local obj = new("Vehicle")

---@generic TCP
---@param a `TCP`2#Comment
---@return TCP
local function new(a) end
local obj = new("Vehicle")



---@param a string?Comment
---@return string?
local function new(a) end
local obj = new("Vehicle")

---@generic T
---@param a T?Comment
---@return T?
local function new(a) end
local obj = new("Vehicle")

---@generic TC
---@param a `TC`?Comment
---@return TC?
local function new(a) end
local obj = new("Vehicle")

---@generic TCP
---@param a `TCP`2?Comment
---@return TCP?
local function new(a) end
local obj = new("Vehicle")



---@param a string[]Comment
---@return string[]
local function new(a) end
local obj = new({"Vehicle"})

---@generic T
---@param a T[]Comment
---@return T[]
local function new(a) end
local obj = new({"Vehicle"})

---@generic TC
---@param a `TC`[]Comment
---@return TC[]
local function new(a) end
local obj = new({"Vehicle"})

---@generic TCP
---@param a `TCP`2[]Comment
---@return TCP[]
local function new(a) end
local obj = new({"Vehicle"})



---@param a string|integer #     the type
---@return string|integer
local function new(a) end
local obj = new("Vehicle")

---@generic T
---@param a T|integer #     the type
---@return T|integer
local function new(a) end
local obj = new("Vehicle")

---@generic TC
---@param a `TC`|integer #     the type
---@return TC|integer
local function new(a) end
local obj = new("Vehicle")

---@generic TCP
---@param a `TCP`2|integer #     the type
---@return TCP|integer
local function new(a) end
local obj = new("Vehicle")
```

</details>

---

- Generic return can be optional.
```lua
---@return T?

local some -- `unknown`
local k, v = next() -- `nil, nil` instead of `unknown, unknown`
local k, v = next({}) -- `nil, nil` instead of `unknown, unknown`
local k, v = next({1}) -- `integer?, integer?` instead of `integer, integer`
local k, v = next({some}) -- `integer?, nil` instead of `integer, unknown`
```
I'm checking the `protoNode (self.proto)` in `generic:resolve`. This node is created in `server\script\vm\compiler.lua:1753` in `: case 'function.return'` where `rtn (proto)` has optional but `vm.createGeneric` is not.
```lua
if hasGeneric then
    ---@cast sign -?
    vm.setNode(source, vm.createGeneric(rtn, sign))
else
    vm.setNode(source, vm.compileNode(rtn))
end
```
But there is some change here. Previously the **optional unresolved generic** was `unknown`, but now it chooses between `unknown|nil` so becomes `nil`
```lua
local some -- `unknown`

-- its correct because generic is `nil`
local k, v = next() -- `nil, nil` instead of `unknown, unknown`

-- is it correct last `nil` with explicit generic `unknown`?
local k, v = next({some}) -- `integer?, nil` instead of `integer, unknown`
```
**I think its OK**, otherwise its different issue.

---

Minor changes
- Removed pattern mask `m.R('__')` from `name` parsing because it the same as `m.S('_')`, so nothing changed.
- Rename `next` variable to `nextTp` to avoid names conflict.
- **NextComment** accepts 2nd argument `boolean` **peek**, not a string `'peek'`.
