### PR TITLE
`duplicate-index` and `duplicate-set-field` change to disabled by default

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@
   ```
 * `NEW` Test CLI: `--name=<testname>` `-n=<testname>`: run specify unit test
 * `FIX` Fixed the error that the configuration file pointed to by the `--configpath` option was not read and loaded.
+* `CHG` The diagnotics check of `duplicate-index` and `duplicate-set-field` features are disabled by default.
 
 ## 3.13.5
 `2024-12-20`

--- a/script/proto/diagnostic.lua
+++ b/script/proto/diagnostic.lua
@@ -203,16 +203,16 @@ m.register {
     'duplicate-index',
 } {
     group    = 'duplicate',
-    severity = 'Warning',
-    status   = 'Any',
+    severity = 'Information',
+    status   = 'None',
 }
 
 m.register {
     'duplicate-set-field',
 } {
     group    = 'duplicate',
-    severity = 'Warning',
-    status   = 'Opened',
+    severity = 'Information',
+    status   = 'None',
 }
 
 m.register {

--- a/script/proto/diagnostic.lua
+++ b/script/proto/diagnostic.lua
@@ -203,7 +203,7 @@ m.register {
     'duplicate-index',
 } {
     group    = 'duplicate',
-    severity = 'Information',
+    severity = 'Warning',
     status   = 'None',
 }
 
@@ -211,7 +211,7 @@ m.register {
     'duplicate-set-field',
 } {
     group    = 'duplicate',
-    severity = 'Information',
+    severity = 'Warning',
     status   = 'None',
 }
 


### PR DESCRIPTION
In order to left and keep Lua as Lua.

1. Make the decorative features check **duplicate-index** and **duplicate-set-field** to be disabled by default.
2. It can be back to enable while the bug of scanning diagnostics being fixed.

The relative issue was talked in [https://github.com/LuaLS/lua-language-server/issues/3035](https://github.com/LuaLS/lua-language-server/issues/3035) and [https://github.com/LuaLS/lua-language-server/issues/3039#issue-2782752530](https://github.com/LuaLS/lua-language-server/issues/3039#issue-2782752530).