### PR TITLE
fix: bind variables with `@class` using tail comments

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,7 @@
 * `FIX` Fixed the error that the configuration file pointed to by the `--configpath` option was not read and loaded.
 * `FIX` Generic return can be optional.
 * `FIX` Fixed the comment calculating in docs `---@param a string?Comment` - now its `Comment` instead of `omment`.
+* `FIX` Fixed cannot bind variables using tail comment `@class` [#2673](https://github.com/LuaLS/lua-language-server/issues/2673)
 * `NEW` `---@class` supports attribute `partial`, which will not check missing inherited fields [#3023](https://github.com/LuaLS/lua-language-server/issues/3023)
   ```lua
   ---@class Config

--- a/script/parser/luadoc.lua
+++ b/script/parser/luadoc.lua
@@ -2181,7 +2181,7 @@ local function bindDocs(state)
         if doc.specialBindGroup then
             bindDocWithSources(sources, doc.specialBindGroup)
             binded = nil
-        elseif isTailComment(text, doc) and doc.type ~= "doc.class" and doc.type ~= "doc.field" then
+        elseif isTailComment(text, doc) and doc.type ~= "doc.field" then
             bindDocWithSources(sources, binded)
             binded = nil
         else


### PR DESCRIPTION
fixes #2673 

這個是我上年最初接觸和使用 luals 時遇到的一個問題
當時由於找到繞過方式用 `@type`，也就解決了

但是最近自某版本起 `@type` 修正成會檢查該 class 的所有 **missing field** 而導致報錯。。。
- 要麼用 disable 方式忽略部分報錯
- 要麼改回用 `@class`

後者好像合理一些
換句話還是得解決最根本的問題：
**連續多行用 tail comment 寫 `@class` 時，無法正確 bind 到 variable**

最初由於不了解 luals 代碼庫，所以也沒有深究原因
現在算是稍為熟悉一點了，很快找到 fix 方式了 🙂 