### PR TITLE
Mark postfix completions as snippets

### DIFF
--- a/script/core/completion/postfix.lua
+++ b/script/core/completion/postfix.lua
@@ -363,6 +363,7 @@ local function checkPostFix(state, word, wordPosition, position, symbol, results
                         newText = newText,
                     },
                     sortText    = ('postfix-%04d'):format(i),
+                    insertTextFormat = 2,
 
                     additionalTextEdits = {
                         {


### PR DESCRIPTION
Similar to 3e0d1df. Postfix items should be marked as snippets.