### PR TITLE
feat: add --check_format=json|pretty

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -30,6 +30,7 @@
   cfgs[2] = {}        -- only warns missing `b`
   ```
   This enables the previous missing field check behavior before [#2970](https://github.com/LuaLS/lua-language-server/issues/2970)
+* `NEW` Added `--check_format=json|pretty` for use with `--check` to output diagnostics in a human readable format.
 
 ## 3.13.5
 `2024-12-20`

--- a/locale/en-us/script.lua
+++ b/locale/en-us/script.lua
@@ -648,8 +648,10 @@ CLI_CHECK_SUCCESS =
 'Diagnosis completed, no problems found'
 CLI_CHECK_PROGRESS =
 'Found {} problems in {} files'
-CLI_CHECK_RESULTS =
+CLI_CHECK_RESULTS_OUTPATH =
 'Diagnosis complete, {} problems found, see {}'
+CLI_CHECK_RESULTS_PRETTY =
+'Diagnosis complete, {} problems found'
 CLI_CHECK_MULTIPLE_WORKERS =
 'Starting {} worker tasks, progress output will be disabled. This may take a few minutes.'
 CLI_DOC_INITING   =

--- a/locale/ja-jp/script.lua
+++ b/locale/ja-jp/script.lua
@@ -649,8 +649,10 @@ CLI_CHECK_SUCCESS =
 '診断が完了しました。問題は見つかりませんでした'
 CLI_CHECK_PROGRESS =
 '{} ファイルに渡り、{} 個の問題が発見されました'
-CLI_CHECK_RESULTS =
+CLI_CHECK_RESULTS_OUTPATH =
 '診断が完了しました。{} 個の問題が発見されました。詳しくは {} をご確認ください'
+CLI_CHECK_RESULTS_PRETTY =
+'診断が完了しました。{} 個の問題が発見されました'
 CLI_CHECK_MULTIPLE_WORKERS =
 '{} 個のワーカータスクを開始しているため、進行状況の出力が無効になります。完了まで数分かかることがあります。'
 CLI_DOC_INITING   =

--- a/locale/pt-br/script.lua
+++ b/locale/pt-br/script.lua
@@ -648,8 +648,10 @@ CLI_CHECK_SUCCESS =
 'Diagnóstico completo, nenhum problema encontrado'
 CLI_CHECK_PROGRESS = -- TODO: need translate!
 'Found {} problems in {} files'
-CLI_CHECK_RESULTS =
+CLI_CHECK_RESULTS_OUTPATH =
 'Diagnóstico completo, {} problemas encontrados, veja {}'
+CLI_CHECK_RESULTS_PRETTY =
+'Diagnóstico completo, {} problemas encontrados'
 CLI_CHECK_MULTIPLE_WORKERS = -- TODO: need translate!
 'Starting {} worker tasks, progress output will be disabled. This may take a few minutes.'
 CLI_DOC_INITING   = -- TODO: need translate!

--- a/locale/zh-cn/script.lua
+++ b/locale/zh-cn/script.lua
@@ -648,8 +648,10 @@ CLI_CHECK_SUCCESS =
 '诊断完成，没有发现问题'
 CLI_CHECK_PROGRESS =
 '检测到问题 {} 在文件 {} 中'
-CLI_CHECK_RESULTS =
+CLI_CHECK_RESULTS_OUTPATH =
 '诊断完成，共有 {} 个问题，请查看 {}'
+CLI_CHECK_RESULTS_PRETTY =
+'诊断完成，共有 {} 个问题'
 CLI_CHECK_MULTIPLE_WORKERS =
 '开启 {} 个工作任务，进度输出将会被禁用。这可能会花费几分钟。'
 CLI_DOC_INITING   =

--- a/locale/zh-tw/script.lua
+++ b/locale/zh-tw/script.lua
@@ -648,8 +648,10 @@ CLI_CHECK_SUCCESS =
 '診斷完成，沒有發現問題'
 CLI_CHECK_PROGRESS = -- TODO: need translate!
 'Found {} problems in {} files'
-CLI_CHECK_RESULTS =
+CLI_CHECK_RESULTS_OUTPATH =
 '診斷完成，共有 {} 個問題，請查看 {}'
+CLI_CHECK_RESULTS_PRETTY =
+'診斷完成，共有 {} 個問題'
 CLI_CHECK_MULTIPLE_WORKERS = -- TODO: need translate!
 'Starting {} worker tasks, progress output will be disabled. This may take a few minutes.'
 CLI_DOC_INITING   = -- TODO: need translate!

--- a/script/global.d.lua
+++ b/script/global.d.lua
@@ -69,6 +69,9 @@ CHECKLEVEL = 'Warning'
 ---@type string|nil
 CHECK_OUT_PATH = ''
 
+---@type string | 'json' | 'pretty'
+CHECK_FORMAT = 'pretty'
+
 ---@type 'trace' | 'debug' | 'info' | 'warn' | 'error'
 LOGLEVEL = 'warn'
 


### PR DESCRIPTION
Adds a new CLI option --check_format which accepts the values: 'json'
(current behaviour), and a new 'pretty' value which prints a colorized
human readable report to stdout, similar to common compilers and
linters.

Results are printed with color unless NO_COLOR is defined in the users
environment, as per https://no-color.org.

If --check_out_path is provided, then the results are always saved to
file regardless of the --check_format value.

I've made `pretty` the default format, however to mitigate against any breakage I've made it also write the json files with `--check_out_path` is provided, so this will be like enabling both formats at once.

### Other changes

- Outlined some functions in `check_worker.lua`.
- Made `--quiet` work properly with `--num_threads`
