### PR TITLE
feat: add variable substitution support for vscode's `${workspaceFolder:x}`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -31,6 +31,7 @@
   cfgs[2] = {}        -- only warns missing `b`
   ```
   This enables the previous missing field check behavior before [#2970](https://github.com/LuaLS/lua-language-server/issues/2970)
+* `NEW` Added variable substitution support for vscode's `${workspaceFolder:x}` when resolving path placeholders [#2987](https://github.com/LuaLS/lua-language-server/issues/2987)
 
 ## 3.13.5
 `2024-12-20`

--- a/script/files.lua
+++ b/script/files.lua
@@ -945,6 +945,17 @@ function m.resolvePathPlaceholders(path)
         elseif key:sub(1, 4) == "env:" then
             local env = os.getenv(key:sub(5))
             return env
+        elseif key == "workspaceFolder" then
+            local ws = require 'workspace'
+            return ws.rootUri and furi.decode(ws.rootUri)
+        elseif key:match("^workspaceFolder:.+$") then
+            local folderName = key:match("^workspaceFolder:(.+)$")
+            for _, scp in ipairs(scope.folders) do
+                if scp:getFolderName() == folderName then
+                    return scp.uri and furi.decode(scp.uri)
+                end
+            end
+            log.warn(('variable ${%s} cannot be resolved when processing path: %s'):format(key, path))
         end
     end)
 

--- a/script/provider/provider.lua
+++ b/script/provider/provider.lua
@@ -119,7 +119,7 @@ m.register 'initialize' {
 
         if params.workspaceFolders then
             for _, folder in ipairs(params.workspaceFolders) do
-                workspace.create(files.getRealUri(folder.uri))
+                workspace.create(files.getRealUri(folder.uri), folder.name)
             end
         elseif params.rootUri then
             workspace.create(files.getRealUri(params.rootUri))

--- a/script/workspace/scope.lua
+++ b/script/workspace/scope.lua
@@ -8,6 +8,7 @@ local m = {}
 ---@class scope
 ---@field type   scope.type
 ---@field uri?   uri
+---@field folderName? string
 ---@field _links table<uri, boolean>
 ---@field _data  table<string, any>
 ---@field _gc    gc
@@ -134,6 +135,11 @@ function mt:getName()
     return self.uri or ('<' .. self.type .. '>')
 end
 
+---@return string?
+function mt:getFolderName()
+    return self.folderName
+end
+
 function mt:gc(obj)
     self._gc:add(obj)
 end
@@ -187,10 +193,12 @@ end
 m.reset()
 
 ---@param uri uri
+---@param folderName? string
 ---@return scope
-function m.createFolder(uri)
+function m.createFolder(uri, folderName)
     local scope = createScope 'folder'
     scope.uri = uri
+    scope.folderName = folderName
 
     local inserted = false
     for i, otherScope in ipairs(m.folders) do

--- a/script/workspace/workspace.lua
+++ b/script/workspace/workspace.lua
@@ -44,9 +44,9 @@ function m.initRoot(uri)
 end
 
 --- 初始化工作区
-function m.create(uri)
+function m.create(uri, folderName)
     log.info('Workspace create: ', uri)
-    local scp = scope.createFolder(uri)
+    local scp = scope.createFolder(uri, folderName)
     m.folders[#m.folders+1] = scp
     if uri == furi.encode '/'
     or uri == furi.encode(os.getenv 'HOME' or '') then


### PR DESCRIPTION
resolves #2987 

---

implementation details: https://github.com/LuaLS/lua-language-server/issues/2987#issuecomment-2603462641
- workspace folder names are captured from client's initialization request param `workspaceFolders[].name`
- if provided, it is then stored into the created `workspace.scope` object
- finally when resolving a `${workspaceFolder:x}` path placeholder
use the decoded `uri` of the `workspace.scope` object that having `x` as the folder name
(which becomes absolute path of that folder)

## Example

- a dummy `_.code-workspace`
```jsonc
{
	"folders": [
		{
			"name": "root",
			"path": "."
		},
		{
			"name": "client",
			"path": "client"
		},
		{
			"name": "server",
			"path": "server"
		}
	],
	"settings": {
		"Lua.workspace.library": [
			"${workspaceFolder:client}",
		]
	}
}
```
- upon inspecting log file, the client is sending the following to server during init
```lua
  workspaceFolders = { {
      name = "root",
      uri = "file:///c%3A/Users/TomLau/test"
    }, {
      name = "client",
      uri = "file:///c%3A/Users/TomLau/test/client"
    }, {
      name = "server",
      uri = "file:///c%3A/Users/TomLau/test/server"
    } }
```
- therefore `${workspaceFolder:client}` will be resolved as `furi.decode('file:///c%3A/Users/TomLau/test/client')`
which becomes `C:\Users\TomLau\test\client`