### PR TITLE
fix: missing field completion for generic class object

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,7 @@
 * `FIX` Generic return can be optional.
 * `FIX` Fixed the comment calculating in docs `---@param a string?Comment` - now its `Comment` instead of `omment`.
 * `FIX` Fixed cannot bind variables using tail comment `@class` [#2673](https://github.com/LuaLS/lua-language-server/issues/2673)
+* `FIX` Fixed missing field completion for generic class object [#2196](https://github.com/LuaLS/lua-language-server/issues/2196) [#2945](https://github.com/LuaLS/lua-language-server/issues/2945) [#3041](https://github.com/LuaLS/lua-language-server/issues/3041)
 * `NEW` `---@class` supports attribute `partial`, which will not check missing inherited fields [#3023](https://github.com/LuaLS/lua-language-server/issues/3023)
   ```lua
   ---@class Config

--- a/script/vm/compiler.lua
+++ b/script/vm/compiler.lua
@@ -304,6 +304,17 @@ local searchFieldSwitch = util.switch()
             end
         end
     end)
+    : case 'doc.type.sign'
+    : call(function (suri, source, key, pushResult)
+        if not source.node[1] then
+            return
+        end
+        local global = vm.getGlobal('type', source.node[1])
+        if not global then
+            return
+        end
+        vm.getClassFields(suri, global, key, pushResult)
+    end)
     : case 'global'
     : call(function (suri, node, key, pushResult)
         if node.cate == 'variable' then

--- a/test/completion/common.lua
+++ b/test/completion/common.lua
@@ -4572,3 +4572,44 @@ M.create():optional(<??>):self()
         kind  = define.CompletionItemKind.EnumMember,
     },
 }
+
+TEST [[
+---@class Array<T>: { [integer]: T }
+---@field length integer
+local Array
+
+function Array:push() end
+
+---@type Array<string>
+local a
+print(a.<??>)
+]]
+{
+    include = true,
+    {
+        label = 'length',
+        kind  = define.CompletionItemKind.Field,
+    },
+    {
+        label = 'push(self)',
+        kind  = define.CompletionItemKind.Method,
+    },
+}
+
+TEST [[
+---@class Array<T>: { [integer]: T }
+---@field length integer
+local Array
+
+function Array:push() end
+
+---@type Array<string>
+local a
+print(a:<??>)
+]]
+{
+    {
+        label = 'push()',
+        kind  = define.CompletionItemKind.Method,
+    },
+}

--- a/test/completion/init.lua
+++ b/test/completion/init.lua
@@ -40,8 +40,18 @@ local function include(a, b)
         return false
     end
     if tp1 == 'table' then
-        for k in pairs(a) do
-            if not eq(a[k], b[k]) then
+        -- a / b are array of completion results
+        -- when checking `include`, the array index order is not important
+        -- thus need to check every results in b
+        for _, v1 in ipairs(a) do
+            local ok = false
+            for _, v2 in ipairs(b) do
+                if eq(v1, v2) then
+                    ok = true
+                    break
+                end
+            end
+            if not ok then
                 return false
             end
         end


### PR DESCRIPTION
fixes #2196, fixes #2945
resolves #3041 (fixing this bug fulfills the requirement of that issue, such that the feature request becomes unnecessary)

---

Bug explanation: https://github.com/LuaLS/lua-language-server/issues/2945#issuecomment-2466563177

### Example after bugfix

```lua
---@class Array<T>: { [integer]: T }
---@field private length integer
local Array

function Array:push()
    self.  --> suggest `length`, `push(self)`
end

---@type Array<string>
local a

print(a.length) --> Field `length` is private, it can only be accessed in class `Array`.

a: --> suggest `push()`
```

### Product placement

CppCXY's new lua language server written in rust has better generic support 😃 
- https://github.com/LuaLS/lua-language-server/issues/3017

---

## 中文版

簡單在 `searchFieldSwitch` 增加對 `doc.type.sign` 的支持，以修復 generic class object 沒有 field completion 的問題。
目前其實還有一個問題，就是 field completion 還會列出 `integer` 😕
似是由 `{ [integer]: T }` 獲取出來的 `integer` key field name
```lua
---@class Array<T>: { [integer]: T }

---@type Array<string>
local a
a. --> why suggest `integer` ??
```
但由於這個問題本身已存在，且我暫時也不清楚原因，就先不在此 PR 糾結了
