### PR TITLE
fix: incorrect arg skip pattern for `--check_out_path=`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 <!-- Add all new changes here. They will be moved under a version at release -->
+* `FIX` incorrect argument skip pattern for `--check_out_path=`, which incorrectly skips the next argument
 
 ## 3.13.6
 `2025-2-6`

--- a/script/cli/check.lua
+++ b/script/cli/check.lua
@@ -21,7 +21,7 @@ local function buildArgs(exe, numThreads, threadId, format, quiet)
             args[#args + 1] = arg:gsub('%-%-%w*', '--check_worker')
         -- --check_out_path needs to be removed if we have more than one thread
         elseif arg:lower():match('%-%-check_out_path') and numThreads > 1 then
-            if not arg:match('%-%-%w*=') then
+            if not arg:match('%-%-[%w_]*=') then
                 skipNext = true
             end
         else


### PR DESCRIPTION
(first thing first, this bug is **NOT** introduced by recent changes)

## Problem

With https://github.com/LuaLS/lua-language-server/pull/3051, now the default check output format is `pretty`.
But I also want to parse the `check.json`, so I added `--check_out_path=xxx` option is my team's project CI:
```bash
${LUALS_PATH}/bin/lua-language-server --check=. --check_out_path=${LUALS_RESULT_FILE} --num_threads=2 --checklevel=Error
```
- But after adding the `--check_out_path=`, I then found that `--num_threads=2` seems not working 😳 
- However if I add `--check_out_path=` at the **end**, it will work 🙄 
  ```bash
  # this works
  ${LUALS_PATH}/bin/lua-language-server --check=. --num_threads=2 --checklevel=Error --check_out_path=${LUALS_RESULT_FILE}
  ```

## Investigation

Upon investigation, I found that the `--num_threads` argument is not passed to check workers if it is placed just after a `--check_out_path=`.
With further debugging, it is due to the incorrect skip pattern for `--check_out_path=`:
https://github.com/LuaLS/lua-language-server/blob/b0b5c8f17fdcb6f8d6244eca48b8fc053e9b15ea/script/cli/check.lua#L23-L24
- `%w` only matches **alphanumeric characters**
- but `check_out_path` contains **underscore** `_`
- => it needs to be `[%w_]` for it to work