### PR TITLE
Build for linux-arm64-musl

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,16 +24,19 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { os: ubuntu-22.04,   target: linux,   platform: linux-x64,   container: 'alpine:latest', libc: musl }
-          - { os: ubuntu-20.04,   target: linux,   platform: linux-x64    }
-          - { os: ubuntu-20.04,   target: linux,   platform: linux-arm64  }
-          - { os: macos-latest,   target: darwin,  platform: darwin-x64   }
-          - { os: macos-latest,   target: darwin,  platform: darwin-arm64 }
-          - { os: windows-latest, target: windows, platform: win32-ia32   }
-          - { os: windows-latest, target: windows, platform: win32-x64    }
+          - { os: ubuntu-22.04,       target: linux,   platform: linux-x64,   container: 'alpine:latest', libc: musl }
+          - { os: ubuntu-20.04,       target: linux,   platform: linux-x64    }
+          - { os: ubuntu-20.04,       target: linux,   platform: linux-arm64  }
+          - { os: ubuntu-22.04-arm,   target: linux,   platform: linux-arm64, container: 'alpine:latest', libc: musl }
+          - { os: macos-latest,       target: darwin,  platform: darwin-x64   }
+          - { os: macos-latest,       target: darwin,  platform: darwin-arm64 }
+          - { os: windows-latest,     target: windows, platform: win32-ia32   }
+          - { os: windows-latest,     target: windows, platform: win32-x64    }
     runs-on: ${{ matrix.os }}
     container:
       image: ${{ matrix.container }}
+      volumes:
+        - /:/host
     steps:
       - name: Install aarch64-linux-gnu
         if: ${{ matrix.platform == 'linux-arm64' && matrix.libc != 'musl' }}
@@ -46,6 +49,15 @@ jobs:
         run: |
           apk update
           apk add git ninja bash build-base nodejs linux-headers
+
+      - name: Prepare container for linux-arm64-musl platform
+        if: ${{ matrix.platform == 'linux-arm64' && matrix.libc == 'musl' }}
+        run: |
+          # workaround to support javascript actions in alpine arm64.
+          # https://github.com/actions/runner/issues/801#issuecomment-2394425757
+          sed -i "s:ID=alpine:ID=NotpineForGHA:" /etc/os-release
+          cd /host/home/runner/runners/*/externals/
+          rm -rf node20/* && mkdir node20/bin && ln -s /usr/bin/node node20/bin/node
 
       - name: Prepare for Linux
         if: ${{ matrix.target == 'linux' && matrix.libc != 'musl' }}
@@ -61,8 +73,8 @@ jobs:
         if: ${{ matrix.target == 'windows' }}
         run: .\make.bat ${{ matrix.platform }}
 
-      - name: Build for Linux
-        if: ${{ matrix.target == 'linux' }}
+      - name: Build for Linux except linux-arm64-musl
+        if: ${{ matrix.target == 'linux' && !(matrix.platform == 'linux-arm64' && matrix.libc == 'musl') }}
         run: |
           ./make.sh ${{ matrix.platform }}
           
@@ -77,6 +89,12 @@ jobs:
         run: |
           docker build -t ubuntu-18.04 .
           docker run --rm -v $(pwd):$(pwd) -w $(pwd) ubuntu-18.04 bash -c './make.sh'
+
+      - name: Build for linux-arm64-musl
+        if: ${{ matrix.platform == 'linux-arm64' && matrix.libc == 'musl' }}
+        run: |
+          ninja -C 3rd/luamake -f compile/ninja/linux.ninja
+          ./3rd/luamake/luamake all
 
       - name: Setting up workflow variables
         id: vars


### PR DESCRIPTION
Closes issue https://github.com/LuaLS/lua-language-server/issues/3066

Updated workflow to build a package for alpine linux arm64-musl. Github currently has some issues with runners for alpine arch64 plarofrm ([check here](https://github.com/actions/runner/issues/801)), so I've added a workaround for this.

Let me know the pr needs some improvements/refactoring. Thanks 🙇 