### PR TITLE
fix: remove extra `./` prefix in check report when using `--check=.`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ## Unreleased
 <!-- Add all new changes here. They will be moved under a version at release -->
 * `FIX` incorrect argument skip pattern for `--check_out_path=`, which incorrectly skips the next argument
+* `FIX` remove extra `./` path prefix in the check report when using `--check=.`
 
 ## 3.13.6
 `2025-2-6`

--- a/script/cli/check_worker.lua
+++ b/script/cli/check_worker.lua
@@ -187,7 +187,7 @@ function export.runCLI()
         return
     end
 
-    local rootPath = fs.absolute(fs.path(CHECK_WORKER)):string()
+    local rootPath = fs.canonical(fs.path(CHECK_WORKER)):string()
     local rootUri = furi.encode(rootPath)
     if not rootUri then
         print(lang.script('CLI_CHECK_ERROR_URI', rootPath))


### PR DESCRIPTION
## problem

When using `--check=.` there will be a `./` in the file path, both in the pretty report and json.
```
tomlau10@TOMLAU-PC /mnt/c/Users/TomLau/test
$ lua-language-server --check=. --check_out_path=check.json
./main.lua:1:10 [Warning] Undefined type or alias `MyClass`. (undefined-doc-name)
    ---@type MyClass
             ^^^^^^^
Diagnosis complete, 1 problems found, see check.json

tomlau10@TOMLAU-PC /mnt/c/Users/TomLau/test
$ cat check.json | grep file
    "file:///mnt/c/Users/TomLau/test/./main.lua": [
```
This exists long ago, and I have been using **jq**'s `sub("^.*?\\./"; "")` when parsing the `check.json` in CI environment.

## investigation

Today my curiosity led me to investigate this issue, and I found the root cause:
- current logic is using `fs.absolute()` from `bee.filesystem` to convert the input argument
https://github.com/LuaLS/lua-language-server/blob/115a518ad995bfc6ae8dabf216451055e1633898/script/cli/check_worker.lua#L190-L191
- however from the cpp reference, `std::filesystem::absolute` returns an **not necessarily canonical** absolute path, which means it can still contain `.` / `..`
https://en.cppreference.com/w/cpp/filesystem/absolute
- to remove the `.` / `..`, we should instead use `std::filesystem::canonical`, which is `fs.canonical()` from `bee.filesystem`
https://en.cppreference.com/w/cpp/filesystem/canonical

## fix result

the `./` is removed 🙂 
```
tomlau10@TOMLAU-PC /mnt/c/Users/TomLau/test
$ lua-language-server --check=. --check_out_path=check.json
main.lua:1:10 [Warning] Undefined type or alias `MyClass`. (undefined-doc-name)
    ---@type MyClass
             ^^^^^^^
Diagnosis complete, 1 problems found, see check.json

tomlau10@TOMLAU-PC /mnt/c/Users/TomLau/test
$ cat check.json | grep file
    "file:///mnt/c/Users/TomLau/test/main.lua": [
```