### PR TITLE
fix: incorrect file names in doc.json

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ## Unreleased
 <!-- Add all new changes here. They will be moved under a version at release -->
 * `FIX` incorrect argument skip pattern for `--check_out_path=`, which incorrectly skips the next argument
+* `FIX` incorrect file names in file doc.json
 
 ## 3.13.6
 `2025-2-6`

--- a/script/cli/doc/export.lua
+++ b/script/cli/doc/export.lua
@@ -8,6 +8,8 @@ local getLabel = require 'core.hover.label'
 local jsonb    = require 'json-beautify'
 local util     = require 'utility'
 local markdown = require 'provider.markdown'
+local fs       = require 'bee.filesystem'
+local furi     = require 'file-uri'
 
 ---@alias doctype
 ---| 'doc.alias'
@@ -55,13 +57,12 @@ local markdown = require 'provider.markdown'
 local export = {}
 
 function export.getLocalPath(uri)
-    --remove uri root (and prefix)
-    local local_file_uri = uri
-    local i, j = local_file_uri:find(DOC)
-    if not j then
-        return '[FOREIGN] '..uri
+    local relativePath = fs.relative(furi.decode(uri), DOC):string()
+    if relativePath:sub(1, 2) == '..' then
+        -- not under project directory
+        return '[FOREIGN] ' .. uri
     end
-    return local_file_uri:sub( j + 1 )
+    return relativePath
 end
 
 function export.positionOf(rowcol)

--- a/script/cli/doc/export.lua
+++ b/script/cli/doc/export.lua
@@ -60,8 +60,7 @@ function export.getLocalPath(uri)
     local file_canonical = fs.canonical(furi.decode(uri)):string()
     local doc_canonical = fs.canonical(DOC):string()
     local relativePath = fs.relative(file_canonical, doc_canonical):string()
-    local _, j = file_canonical:find(doc_canonical, 1, true)
-    if not j then
+    if relativePath == "" or relativePath:sub(1, 2) == '..' then
         -- not under project directory
         return '[FOREIGN] ' .. file_canonical
     end

--- a/script/cli/doc/export.lua
+++ b/script/cli/doc/export.lua
@@ -57,10 +57,13 @@ local furi     = require 'file-uri'
 local export = {}
 
 function export.getLocalPath(uri)
-    local relativePath = fs.relative(furi.decode(uri), DOC):string()
-    if relativePath:sub(1, 2) == '..' then
+    local file_canonical = fs.canonical(furi.decode(uri)):string()
+    local doc_canonical = fs.canonical(DOC):string()
+    local relativePath = fs.relative(file_canonical, doc_canonical):string()
+    local _, j = file_canonical:find(doc_canonical, 1, true)
+    if not j then
         -- not under project directory
-        return '[FOREIGN] ' .. uri
+        return '[FOREIGN] ' .. file_canonical
     end
     return relativePath
 end

--- a/script/cli/doc/init.lua
+++ b/script/cli/doc/init.lua
@@ -185,7 +185,7 @@ function doc.runCLI()
         return
     end
 
-    local rootUri = furi.encode(fs.absolute(fs.path(DOC)):string())
+    local rootUri = furi.encode(fs.canonical(fs.path(DOC)):string())
     if not rootUri then
         print(lang.script('CLI_CHECK_ERROR_URI', DOC))
         return


### PR DESCRIPTION
Fixes #2971

File names in doc.json were broken since #2821.
