### PR TITLE
fix: default path for --doc_out_path is the current directory

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 <!-- Add all new changes here. They will be moved under a version at release -->
-* `FIX` incorrect argument skip pattern for `--check_out_path=`, which incorrectly skips the next argumen
+* `FIX` incorrect argument skip pattern for `--check_out_path=`, which incorrectly skips the next argument
 * `CHG` default path for `--doc_out_path` is the current directory
 * `FIX` remove extra `./` path prefix in the check report when using `--check=.`
 

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ## Unreleased
 <!-- Add all new changes here. They will be moved under a version at release -->
 * `FIX` incorrect argument skip pattern for `--check_out_path=`, which incorrectly skips the next argument
+* `CHG` default path for `--doc_out_path` is the current directory
 
 ## 3.13.6
 `2025-2-6`

--- a/script/cli/doc/init.lua
+++ b/script/cli/doc/init.lua
@@ -242,6 +242,10 @@ function doc.runCLI()
         end)
         io.write('\x0D')
 
+        if not DOC_OUT_PATH then
+            DOC_OUT_PATH = fs.current_path():string()
+        end
+
         local ok, outPaths, err = dirty_export.serializeAndExport(docs, DOC_OUT_PATH)
         print(lang.script('CLI_DOC_DONE'))
         for i, path in ipairs(outPaths) do


### PR DESCRIPTION
Fixes #3073

Back then the default path of doc.json was LOGPATH. However the default path got lost after a refactoring in #2821. This commit reimplements the default path, but changes the default to the current directory.