### PR TITLE
fix: osdate is not allowed in `os.time`

### DIFF
--- a/meta/template/os.lua
+++ b/meta/template/os.lua
@@ -9,7 +9,7 @@ os = {}
 ---@nodiscard
 function os.clock() end
 
----@class osdate
+---@class osdate:osdateparam
 ---#DES 'osdate.year'
 ---@field year  integer|string
 ---#DES 'osdate.month'


### PR DESCRIPTION
Using `os.time()` with an `osdate` type input is currently not allowed, only `osdateparam` is allowed.

```lua
---@type osdate
local date
dosomething(os.time(date))
--- Cannot assign `osdate` to parameter `osdateparam?`.
--- - `osdate` cannot match `osdateparam?`
--- - Type `osdate` cannot match `nil`
--- - Type `osdate` cannot match `osdateparam`Lua Diagnostics.(param-type-mismatch)
```

This simple change makes so that `osdate` is a child of `osdateparam`, and as such can be used in all curcumstances an `osdateparam` would be acceptable.
