### PR TITLE
fix: another regression related to type narrow and generic since v3.10.1

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@
 * `FIX` reimplement section `luals.config` in file doc.json
 * `FIX` incorrect file names in file doc.json
 * `FIX` remove extra `./` path prefix in the check report when using `--check=.`
+* `FIX` Another regression related to type narrow and generic param introduced since `v3.10.1` [#3087](https://github.com/LuaLS/lua-language-server/issues/3087)
 
 ## 3.13.6
 `2025-2-6`

--- a/script/vm/compiler.lua
+++ b/script/vm/compiler.lua
@@ -641,20 +641,11 @@ local function matchCall(source)
         newNode.originNode = myNode
         vm.setNode(source, newNode, true)
         if call.args then
-            -- clear existing node caches of args to allow recomputation with the type narrowed call
+            -- recompile existing node caches of args to allow recomputation with the type narrowed call
             for _, arg in ipairs(call.args) do
                 if vm.getNode(arg) then
-                    vm.setNode(arg, vm.createNode(), true)
-                end
-            end
-            for n in newNode:eachObject() do
-                if n.type == 'function'
-                or n.type == 'doc.type.function' then
-                    for i, arg in ipairs(call.args) do
-                        if vm.getNode(arg) and n.args[i] then
-                            vm.setNode(arg, vm.compileNode(n.args[i]))
-                        end
-                    end
+                    vm.removeNode(arg)
+                    vm.compileNode(arg)
                 end
             end
         end

--- a/test/type_inference/common.lua
+++ b/test/type_inference/common.lua
@@ -4718,6 +4718,46 @@ local function f(v) end
 local <?r?> = f('')
 ]]
 
+TEST 'A' [[
+---@class A
+local A = {}
+
+---@generic T
+---@param self T
+---@param s string
+---@return T
+function A:f(s) end
+
+---@generic T
+---@param self T
+---@param i integer
+---@return T
+function A:f(i) end
+
+local <?r?> = A:f('')
+]]
+
+TEST 'B' [[
+---@class A
+local A = {}
+
+---@generic T
+---@param self T
+---@param s string
+---@return T
+function A:f(s) end
+
+---@generic T
+---@param self T
+---@param i integer
+---@return T
+function A:f(i) end
+
+---@class B: A
+local B = {}
+local <?r?> = B:f('')
+]]
+
 TEST 'integer' [[
 local function F(...)
     local t = {...}


### PR DESCRIPTION
fixes #3087
debugging and explanation: https://github.com/LuaLS/lua-language-server/issues/3087#issuecomment-2676653835

## 中文版

- `3.10.1` 中 https://github.com/LuaLS/lua-language-server/commit/8ecec08 的改動應該是有問題
目前出現另1個 regression issue 跟這改動有關
- 具體問題原因我還沒搞清楚
不過現在回看，該 fix 實際上過於複雜了 😂 
- https://github.com/LuaLS/lua-language-server/commit/8ecec08 是為了修正 #2776 
而 issue 2776  的主要問題，似單純是 **如果某 arg node 已經 compile 過，說明在相同 callstack 後邊需要被引用**
=> 不能單純做 remove，否則會導致 **error: index nil value**
=> 換句話其實在 remove 後直接 recompile 一次應該就可以 🤔 