### PR TITLE
fix: fix type annotations for bit module

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@
 * `FIX` reimplement section `luals.config` in file doc.json
 * `FIX` incorrect file names in file doc.json
 * `FIX` remove extra `./` path prefix in the check report when using `--check=.`
+* `FIX` fix type annotations for bit module
 
 ## 3.13.6
 `2025-2-6`

--- a/meta/template/bit.lua
+++ b/meta/template/bit.lua
@@ -22,25 +22,22 @@ function bit.tohex(x, n) end
 function bit.bnot(x) end
 
 ---@param x   integer
----@param x2  integer
 ---@param ... integer
 ---@return integer y
 ---@nodiscard
-function bit.bor(x, x2, ...) end
+function bit.bor(x, ...) end
 
 ---@param x   integer
----@param x2  integer
 ---@param ... integer
 ---@return integer y
 ---@nodiscard
-function bit.band(x, x2, ...) end
+function bit.band(x, ...) end
 
 ---@param x   integer
----@param x2  integer
 ---@param ... integer
 ---@return integer y
 ---@nodiscard
-function bit.bxor(x, x2, ...) end
+function bit.bxor(x, ...) end
 
 ---@param x integer
 ---@param n integer


### PR DESCRIPTION
Specifically for function `bor`, `band` and `bxor`, which all only
require one mandatory argument.

Reference: https://bitop.luajit.org/api.html
