### PR TITLE
Correct version for `math.type` and `math.ult`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@
 * `FIX` reimplement section `luals.config` in file doc.json
 * `FIX` incorrect file names in file doc.json
 * `FIX` remove extra `./` path prefix in the check report when using `--check=.`
+* `FIX` correct lua version of `math.ult` and `math.type`
 
 ## 3.13.6
 `2025-2-6`

--- a/meta/template/math.lua
+++ b/meta/template/math.lua
@@ -234,6 +234,7 @@ function math.tanh(x) end
 ---@nodiscard
 function math.tointeger(x) end
 
+---@version >5.3
 ---#DES 'math.type'
 ---@param x any
 ---@return
@@ -243,6 +244,7 @@ function math.tointeger(x) end
 ---@nodiscard
 function math.type(x) end
 
+---@version >5.3
 ---#DES 'math.ult'
 ---@param m integer
 ---@param n integer


### PR DESCRIPTION
`math.type` and `math.ult` were added in Lua 5.3. The annotations for these functions didn't reflect this.