### PR TITLE
FIX .luarc.json not being found in certain workspace using zed

### DIFF
--- a/script/files.lua
+++ b/script/files.lua
@@ -99,7 +99,7 @@ function m.getRealUri(uri)
     if uri == ruri then
         return ruri
     end
-    local real = getRealParent(path:parent_path()) / res:filename()
+    local real = getRealParent(path:parent_path())
     ruri = furi.encode(real:string())
     if uri == ruri then
         return ruri


### PR DESCRIPTION
removed `res:filename()` since its already appended by `getRealParent` 

when using in a workspace using [Zed](https://zed.dev/) it would always add twice the folder at the end of the path causing the config file to not being found 