### PR TITLE
Add missing comparison operators

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,8 @@
 # changelog
 
 ## Unreleased
-<!-- Add all new changes here. They will be moved under a version at release -->
+`2025-3-26`
+* `FIX` add missing comparison operators `eq`, `lt`, and `le`
 
 ## 3.13.9
 `2025-3-13`

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # changelog
 
 ## Unreleased
+<!-- Add all new changes here. They will be moved under a version at release -->
 `2025-3-26`
 * `FIX` add missing comparison operators `eq`, `lt`, and `le`
 

--- a/script/vm/operator.lua
+++ b/script/vm/operator.lua
@@ -23,6 +23,9 @@ vm.BINARY_OP = {
     'shl',
     'shr',
     'concat',
+    'eq',
+    'lt',
+    'le',
 }
 vm.OTHER_OP = {
     'call',
@@ -48,6 +51,9 @@ local binaryMap = {
     ['<<'] = 'shl',
     ['>>'] = 'shr',
     ['..'] = 'concat',
+    ['=='] = 'eq',
+    ['<='] = 'le',
+    ['<']  = 'lt',
 }
 
 local otherMap = {


### PR DESCRIPTION
I noticed that eq was not being recognized by the language server. Adding the missing eq, lt, and le entries to vm.BINARY_OP and binaryMap resolves this issue.