### PR TITLE
[fix] Linux debugging server not starting

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 <!-- Add all new changes here. They will be moved under a version at release -->
+* `FIX` cannot debug in Linux due to lua-debug expecting host process to have lua54 symbols available
 
 ## 3.14.0
 `2025-4-7`

--- a/make.lua
+++ b/make.lua
@@ -51,6 +51,7 @@ lm:executable "lua-language-server" {
     },
     linux = {
         crt = "static",
+        ldflags = { "-rdynamic" },
     }
 }
 


### PR DESCRIPTION
This PR fixes the `--dbgport=xxx` option not working in Linux. The following could be seen in the logs:

```
$HOME/.vscode/extensions/actboy168.lua-debug-2.0.12-linux-x64/runtime/linux-x64/lua54/luadebug.so: undefined symbol: lua_getmetatable
```

This error comes from the fact that the host process (lua language server) does not expose lua54 symbols for `luadebug.so` to use.

The fix adds a compilation flag that will be used by `luamake` and will incorporate those symbols.