### PR TITLE
[feat] generics: capture types with backticks

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 <!-- Add all new changes here. They will be moved under a version at release -->
+* `NEW` Allow capture object types with backticks in generics
 
 ## 3.13.9
 `2025-3-13`

--- a/script/vm/sign.lua
+++ b/script/vm/sign.lua
@@ -51,9 +51,29 @@ function mt:resolve(uri, args)
             if object.literal then
                 -- 'number' -> `T`
                 for n in node:eachObject() do
+                    local typeName = nil
+                    local typeUri = nil
                     if n.type == 'string' then
+                        typeName = n[1]
+                        typeUri = guide.getUri(n)
+                    elseif n.type == "global" and n.cate == "type" then
+                        typeName = n:getName()
+                    elseif (n.type == "function" or n.type == "doc.type.function")
+                        and #n.returns > 0 then
                         ---@cast n parser.object
-                        local type = vm.declareGlobal('type', object.pattern and object.pattern:format(n[1]) or n[1], guide.getUri(n))
+                        local fret = vm.getReturnOfFunction(n, 1)
+                        if fret then
+                            local compiled = vm.compileNode(fret)
+                            local r1 = compiled and compiled[1]
+                            if r1 and r1.cate == "type" then
+                                typeName = r1:getName()
+                            end
+						end
+                    end
+                    if typeName ~= nil then
+                        ---@cast n parser.object
+                        local type = vm.declareGlobal('type',
+                            object.pattern and object.pattern:format(typeName) or typeName, typeUri)
                         resolved[key] = vm.createNode(type, resolved[key])
                     end
                 end

--- a/test/definition/luadoc.lua
+++ b/test/definition/luadoc.lua
@@ -293,7 +293,7 @@ print(v1.<?bar1?>)
 TEST [[
 ---@class Foo
 local Foo = {}
-function Foo:bar1() end
+function Foo:<!bar1!>() end
 
 ---@generic T
 ---@param arg1 `T`
@@ -403,6 +403,43 @@ print(v1.<?bar1?>)
 ]]
 
 TEST [[
+---@class n.Foo.2
+local nFoo2 = {}
+function nFoo2:<!bar1!>() end
+
+---@class Foo
+local Foo = {}
+
+---@generic T
+---@param arg1 n.`T`.2
+---@return T
+function Generic(arg1) print(arg1) end
+
+local v1 = Generic(Foo)
+print(v1.<?bar1?>)
+]]
+
+TEST [[
+---@class n.Foo.2
+local nFoo2 = {}
+function nFoo2:<!bar1!>() end
+
+---@class Foo
+local Foo = {}
+
+---@return Foo
+function returnsFoo() print("") end
+
+---@generic T
+---@param arg1 n.`T`.2
+---@return T
+function Generic(arg1) print(arg1) end
+
+local v1 = Generic(returnsFoo())
+print(v1.<?bar1?>)
+]]
+
+TEST [[
 ---@class n-Foo-2
 local Foo = {}
 function Foo:bar1() end
@@ -427,6 +464,23 @@ function Foo:<!bar1!>() end
 function Generic(arg1) print(arg1) end
 
 local v1 = Generic({"Foo"})
+print(v1.<?bar1?>)
+]]
+
+TEST [[
+---@class n-Foo-2
+local nFoo2 = {}
+function nFoo2:<!bar1!>() end
+
+---@class Foo
+local Foo = {}
+
+---@generic T
+---@param arg1 n-`T`-2[]
+---@return T
+function Generic(arg1) print(arg1) end
+
+local v1 = Generic({Foo})
 print(v1.<?bar1?>)
 ]]
 


### PR DESCRIPTION
This PR modifies the generics capture system to allow to capture types out of the type of the parameter passed, in addition to being able to pass the type as a string which is the way it currently works:

Currently:
```lua
---@class Vehicle
local Vehicle = {}

---@class VehicleColor
local VehicleColor = {}

---@generic T
---@param class `T`Color # the type is captured using `T`
---@return T       # T becomes class + "Color"
local function getItemColor(class) end

-- obj: is of type VehicleColor
local obj = getItemColor("Vehicle")
```

Now, the following is also possible:

```lua
---@class Vehicle
local Vehicle = {}

---@class VehicleColor
local VehicleColor = {}

---@generic T
---@param class `T`Color # the type is captured using `T`
---@return T       # T becomes typeof(class) + "Color"
local function getItemColor(class) end

---@type Vehicle
local someVehicle = {}

-- obj: is of type VehicleColor
local obj = getItemColor(someVehicle)

-- obj2: is of type VehicleColor
local obj2 = getItemColor("Vehicle")

```

Therefore, it is possible to pass a literal string that happens to be a type name like before, or otherwise pass an expression that evaluates to a type and that type will be captured with backticks. This allows to construct typings for functions that return different types that depend on the type of the object passed.




