### PR TITLE
Support Custom Addons Path for Enhanced Editor Flexibility

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ## Unreleased
 <!-- Add all new changes here. They will be moved under a version at release -->
 * `FIX` cannot debug in Linux due to lua-debug expecting host process to have lua54 symbols available
+* `NEW` support custom addons path for enhanced editor flexibility
 
 ## 3.14.0
 `2025-4-7`

--- a/doc/en-us/config.md
+++ b/doc/en-us/config.md
@@ -14,6 +14,16 @@ boolean
 true
 ```
 
+# addonRepositoryPath
+
+Specifies the addon repository path (not related to the addon manager).
+
+## type
+
+```ts
+string
+```
+
 # codeLens.enable
 
 Enable code lens.

--- a/doc/pt-br/config.md
+++ b/doc/pt-br/config.md
@@ -14,6 +14,16 @@ boolean
 true
 ```
 
+# addonRepositoryPath
+
+Specifies the addon repository path (not related to the addon manager).
+
+## type
+
+```ts
+string
+```
+
 # codeLens.enable
 
 Enable code lens.

--- a/doc/zh-cn/config.md
+++ b/doc/zh-cn/config.md
@@ -14,6 +14,16 @@ boolean
 true
 ```
 
+# addonRepositoryPath
+
+指定插件仓库的路径（与 Addon Manager 无关）。
+
+## type
+
+```ts
+string
+```
+
 # codeLens.enable
 
 启用代码度量。

--- a/doc/zh-tw/config.md
+++ b/doc/zh-tw/config.md
@@ -14,6 +14,16 @@ boolean
 true
 ```
 
+# addonRepositoryPath
+
+Specifies the addon repository path (not related to the addon manager).
+
+## type
+
+```ts
+string
+```
+
 # codeLens.enable
 
 Enable code lens.

--- a/locale/en-us/setting.lua
+++ b/locale/en-us/setting.lua
@@ -6,6 +6,8 @@ config.addonManager.repositoryBranch =
 "Specifies the git branch used by the addon manager."
 config.addonManager.repositoryPath =
 "Specifies the git path used by the addon manager."
+config.addonRepositoryPath        =
+"Specifies the addon repository path (not related to the addon manager)."
 config.runtime.version            =
 "Lua runtime version."
 config.runtime.path               =

--- a/locale/es-419/setting.lua
+++ b/locale/es-419/setting.lua
@@ -6,6 +6,8 @@ config.addonManager.repositoryBranch =
 "Especifica la rama de git usada por el manejador de extensiones."
 config.addonManager.repositoryPath =
 "Especifica la ruta git usada por el manejador de extensiones."
+config.addonRepositoryPath        = -- TODO: need translate!
+"Specifies the addon repository path (not related to the addon manager)."
 
 config.runtime.version            =
 "Versión de Lua que se ejecuta."

--- a/locale/ja-jp/setting.lua
+++ b/locale/ja-jp/setting.lua
@@ -6,6 +6,8 @@ config.addonManager.repositoryBranch = -- TODO: need translate!
 "Specifies the git branch used by the addon manager."
 config.addonManager.repositoryPath = -- TODO: need translate!
 "Specifies the git path used by the addon manager."
+config.addonRepositoryPath        = -- TODO: need translate!
+"Specifies the addon repository path (not related to the addon manager)."
 config.runtime.version            = -- TODO: need translate!
 "Lua runtime version."
 config.runtime.path               = -- TODO: need translate!

--- a/locale/pt-br/setting.lua
+++ b/locale/pt-br/setting.lua
@@ -6,6 +6,8 @@ config.addonManager.repositoryBranch = -- TODO: need translate!
 "Specifies the git branch used by the addon manager."
 config.addonManager.repositoryPath = -- TODO: need translate!
 "Specifies the git path used by the addon manager."
+config.addonRepositoryPath        = -- TODO: need translate!
+"Specifies the addon repository path (not related to the addon manager)."
 config.runtime.version            = -- TODO: need translate!
 "Lua runtime version."
 config.runtime.path               = -- TODO: need translate!

--- a/locale/zh-cn/setting.lua
+++ b/locale/zh-cn/setting.lua
@@ -6,6 +6,8 @@ config.addonManager.repositoryBranch =
 "指定插件管理器(Addon Manager)使用的git仓库分支"
 config.addonManager.repositoryPath =
 "指定插件管理器(Addon Manager)使用的git仓库路径"
+config.addonRepositoryPath        =
+"指定插件仓库的路径（与 Addon Manager 无关）"
 config.runtime.version            =
 "Lua运行版本。"
 config.runtime.path               =

--- a/locale/zh-tw/setting.lua
+++ b/locale/zh-tw/setting.lua
@@ -6,6 +6,8 @@ config.addonManager.repositoryBranch = -- TODO: need translate!
 "Specifies the git branch used by the addon manager."
 config.addonManager.repositoryPath = -- TODO: need translate!
 "Specifies the git path used by the addon manager."
+config.addonRepositoryPath        = -- TODO: need translate!
+"Specifies the addon repository path (not related to the addon manager)."
 config.runtime.version            =
 "Lua執行版本。"
 config.runtime.path               =

--- a/script/config/template.lua
+++ b/script/config/template.lua
@@ -414,6 +414,7 @@ local template = {
                                             },
     --testma
     ["Lua.docScriptPath"]                   = Type.String,
+    ["Lua.addonRepositoryPath"]             = Type.String,
     -- VSCode
     ["Lua.addonManager.enable"]             = Type.Boolean >> true,
     ["Lua.addonManager.repositoryPath"]     = Type.String,

--- a/script/files.lua
+++ b/script/files.lua
@@ -908,6 +908,25 @@ end
 
 local addonsPath
 
+---Updates the variable 'addonsPath' with the user's configuration.
+---The path is only updated if 'addonsPath' is not set and the provided path is a valid string.
+---It first expands the input path and then verifies its existence via fs.exists.
+---@param path string
+function m.updateAddonsPath(path)
+    if addonsPath then
+        return
+    end
+    if not (path and type(path) == "string") then
+        return
+    end
+
+    path = util.expandPath(fs.path(path):string())
+    if fs.exists(fs.path(path)) then
+        addonsPath = path
+        log.info('Updating addon repository path to: ', path)
+    end
+end
+
 ---Resolve path variables/placeholders like ${3rd} and ${addons}
 ---@param path string
 ---@return string resolvedPath

--- a/script/workspace/workspace.lua
+++ b/script/workspace/workspace.lua
@@ -131,6 +131,7 @@ local globInteferFace = {
     end
 }
 
+local addonRepositoryPathUpdated = false
 --- 创建排除文件匹配器
 ---@param scp scope
 function m.getNativeMatcher(scp)
@@ -175,6 +176,11 @@ function m.getNativeMatcher(scp)
         end
     end
     for _, path in ipairs(config.get(scp.uri, 'Lua.workspace.library')) do
+        if not addonRepositoryPathUpdated then
+            addonRepositoryPathUpdated = true
+            local addonRepositoryPath = config.get(scp.uri, 'Lua.addonRepositoryPath')
+            files.updateAddonsPath(addonRepositoryPath)
+        end
         path = m.getAbsolutePath(scp.uri, path)
         if path then
             log.debug('Ignore by library:', path)


### PR DESCRIPTION
This pull request enables users to specify a custom addons path for 3rd-party libraries, addressing the current limitation where only the VSCode-addons path is used.

Highlights:
- Adds `files.updateAddonsPath` to let users update the `addonsPath` if it has not been configured already.
- Validates the provided path using `fs.exists` after expanding it via `util.expandPath`.
- Extends the language server's usability beyond VSCode to support editors like Vim/Neovim.

Currently the configuration `Lua.addonRepositoryPath` has a higher priority, but if it's not set, it won't affect the addon manager in vscode.

Example:

1. Clone the addon repo, let's say the command is execute under `/tmp` so a folder `/tmp/LLS-addons` will be created with all the submodules.
    ```bash
    git clone --recurse-submodules https://github.com/LuaLS/LLS-Addons
    ```
2. In the client configuration, for example neovim:
    ```lua
    vim.lsp.config('lua_ls', {
      on_init = function(client)
        client.config.settings.Lua = vim.tbl_deep_extend('force', client.config.settings.Lua, {
          -- don't forget the `addons` folder
          -- if it's somewhere under the `$HOME` directory, you can also use `~/path/to/LLS-Addons/addons`
          addonRepositoryPath = '/tmp/LLS-Addons/addons',
          -- other configurations
        })
      end,
      settings = { Lua = {} }
    })
    ```
3. To add support of a library (e.g. `penlight`) in a project, config `.luarc.json` like this:
    ```json
    {
        "workspace.library": [
            "${addons}/penlight/module/library",
        ]
    }
    ```
