### PR TITLE
feat: support hex color with `#`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ## Unreleased
 <!-- Add all new changes here. They will be moved under a version at release -->
 * `FIX` cannot debug in Linux due to lua-debug expecting host process to have lua54 symbols available
+* `FIX` support hex color codes with `#` in `textDocument/documentColor`
 
 ## 3.14.0
 `2025-4-7`

--- a/script/core/color.lua
+++ b/script/core/color.lua
@@ -2,15 +2,21 @@ local files = require "files"
 local guide = require "parser.guide"
 
 local colorPattern = string.rep('%x', 8)
+local hex6Pattern = string.format("^#%s", string.rep('%x', 6))
 ---@param source parser.object
 ---@return boolean
 local function isColor(source)
     ---@type string
     local text = source[1]
-    if text:len() ~= 8 then
-        return false
+    if text:len() == 8 then
+        return text:match(colorPattern)
     end
-    return text:match(colorPattern)
+
+    if text:len() == 7 then
+        return text:match(hex6Pattern)
+    end
+
+    return false
 end
 
 
@@ -25,6 +31,16 @@ local function textToColor(colorText)
     }
 end
 
+---@param colorText string
+---@return Color
+local function hexTextToColor(colorText)
+    return {
+        alpha = 255,
+        red   = tonumber(colorText:sub(2, 3), 16) / 255,
+        green = tonumber(colorText:sub(4, 5), 16) / 255,
+        blue  = tonumber(colorText:sub(6, 7), 16) / 255,
+    }
+end
 
 ---@param color Color
 ---@return string
@@ -63,10 +79,12 @@ local function colors(uri)
             ---@type string
             local colorText = source[1]
 
+            local color = colorText:match(colorPattern) and textToColor(colorText) or hexTextToColor(colorText)
+
             colorValues[#colorValues+1] = {
                 start  = source.start + 1,
                 finish = source.finish - 1,
-                color  = textToColor(colorText)
+                color  = color
             }
         end
     end)


### PR DESCRIPTION
I am using neovim, and neovim recently got support for `textDocument/documentColor`.

I also have a colortheme defined in my config, where I have a bunch of hex colors like `#a6e3a2`. It would be really nice if this server could support the colors in this format😅

This PR adds support for this, and seems to be working pretty good for me

Before:
<img width="341" alt="image" src="https://github.com/user-attachments/assets/0c567333-5847-4fea-af1b-8b176c3825cb" />

After:
<img width="270" alt="image" src="https://github.com/user-attachments/assets/608a7ea6-629b-4fba-83af-e751d587bf85" />
