### PR TITLE
Add support for `getmetatable`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 <!-- Add all new changes here. They will be moved under a version at release -->
 * `FIX` cannot debug in Linux due to lua-debug expecting host process to have lua54 symbols available
 * `FIX` support hex color codes with `#` in `textDocument/documentColor`
+* `NEW` type reference from `getmetatable` is supported now
 
 ## 3.14.0
 `2025-4-7`

--- a/script/parser/compile.lua
+++ b/script/parser/compile.lua
@@ -108,6 +108,7 @@ local Specials = {
     ['rawset']       = true,
     ['rawget']       = true,
     ['setmetatable'] = true,
+    ['getmetatable'] = true,
     ['require']      = true,
     ['dofile']       = true,
     ['loadfile']     = true,


### PR DESCRIPTION
Show case:

```lua
local a = {x = 111}
local mt = {__index = a, __metatable = a, k = 111}
local b = setmetatable({y = 2}, mt)

-- 1. Firstly, giving type info instead of an empty `table`
-- 2. `mt` have `__metatable`, so `c` is `a`
local c = getmetatable(b) 

local mt1 = {__index = a, k = 111}
local d = setmetatable({z = 3}, mt1)

-- 1. Firstly, giving type info instead of an empty `table`
-- 2. `mt1` doesn't have `__metatable`, so `e` is `mt1`
local e = getmetatable(d)
```