### PR TITLE
fix: large unions no longer erroneously fail to match later variants

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,8 @@
 * `FIX` Prevent class methods from triggering missing-fields diagnostics
 * `ADD` missing locale
 * `FIX` updates the EmmyLuaCodeStyle submodule reference to a newer commit, ensuring compatibility with GCC 15
+* `FIX` large unions will no longer erroneously fail to match later variants
+* `ADD` Lua.type.maxUnionVariants which can be set to limit how many union variants are checked against
 
 ## 3.14.0
 `2025-4-7`

--- a/script/config/template.lua
+++ b/script/config/template.lua
@@ -401,6 +401,7 @@ local template = {
     ['Lua.language.completeAnnotation']     = Type.Boolean >> true,
     ['Lua.type.castNumberToInteger']        = Type.Boolean >> true,
     ['Lua.type.weakUnionCheck']             = Type.Boolean >> false,
+    ['Lua.type.maxUnionVariants']           = Type.Integer >> 0,
     ['Lua.type.weakNilCheck']               = Type.Boolean >> false,
     ['Lua.type.inferParamType']             = Type.Boolean >> false,
     ['Lua.type.checkTableShape']            = Type.Boolean >> false,

--- a/script/vm/type.lua
+++ b/script/vm/type.lua
@@ -374,10 +374,11 @@ function vm.isSubType(uri, child, parent, mark, errs)
     elseif child.type == 'vm.node' then
         if config.get(uri, 'Lua.type.weakUnionCheck') then
             local hasKnownType = 0
+            local maxUnionVariants = config.get(uri, 'Lua.type.maxUnionVariants') or 0
             local i = 0
             for n in child:eachObject() do
                 i = i + 1
-                if i > 100 then
+                if maxUnionVariants > 0 and i > maxUnionVariants then
                     break
                 end
                 if vm.getNodeName(n) then
@@ -403,10 +404,11 @@ function vm.isSubType(uri, child, parent, mark, errs)
         else
             local weakNil = config.get(uri, 'Lua.type.weakNilCheck')
             local skipTable
+            local maxUnionVariants = config.get(uri, 'Lua.type.maxUnionVariants') or 0
             local i = 0
             for n in child:eachObject() do
                 i = i + 1
-                if i > 100 then
+                if maxUnionVariants > 0 and i > maxUnionVariants then
                     break
                 end
                 if skipTable == nil and n.type == "table" and parent.type == "vm.node" then -- skip table type check if child has class
@@ -473,10 +475,11 @@ function vm.isSubType(uri, child, parent, mark, errs)
         parent = global
     elseif parent.type == 'vm.node' then
         local hasKnownType = 0
+        local maxUnionVariants = config.get(uri, 'Lua.type.maxUnionVariants') or 0
         local i = 0
         for n in parent:eachObject() do
             i = i + 1
-            if i > 100 then
+            if maxUnionVariants > 0 and i > maxUnionVariants then
                 break
             end
             if vm.getNodeName(n) then


### PR DESCRIPTION
Close #3178 and close #3126 by adding a config option `Lua.type.maxUnionVariants` to control how many union variants a value is checked against. By default, the setting is set to 0, meaning that the language server will check all union variants. 

Further work to improve ergonomics with this setting might include adding a warning when a union type is defined that has too many variants.