### PR TITLE
fix: incorrect inject field message for exact class extra field

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 <!-- Add all new changes here. They will be moved under a version at release -->
+* `FIX` Incorrect inject-field message for extra table field in exact class
 
 ## 3.15.0
 `2025-6-25`

--- a/script/core/diagnostics/inject-field.lua
+++ b/script/core/diagnostics/inject-field.lua
@@ -134,7 +134,7 @@ return function (uri, callback)
             end
             local message = lang.script('DIAG_INJECT_FIELD', {
                 class = vm.getInfer(src):view(uri),
-                field = guide.getKeyName(src),
+                field = guide.getKeyName(field),
                 fix   = '',
             })
             callback {


### PR DESCRIPTION
I found this display bug while discussing in an issue: https://github.com/LuaLS/lua-language-server/issues/3211#issuecomment-3008185862

### before
```lua
---@class (exact) A
---@field a integer
local A = {
    b = 1,  --> Fields cannot be injected into the reference of `A` for `A`.
}
```
=> the msg incorrectly uses class name `` `A` for `A` ``

### after
```lua
---@class (exact) A
---@field a integer
local A = {
    b = 1,  --> Fields cannot be injected into the reference of `A` for `b`.
}
```
=> the correct msg should be using the field name `` `A` for `b` ``