### PR TITLE
feat: add '|lambda|' to nonstandardSymbol in template

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 <!-- Add all new changes here. They will be moved under a version at release -->
+* adds the `|lambda|` operator to the `Lua.runtime.nonstandardSymbol` configuration template, which allows the use of that option. Previously, support for it existed in the parser, but we could not actually use the option because it is not recognised in the configuration.
 
 ## 3.15.0
 `2025-6-25`

--- a/script/config/template.lua
+++ b/script/config/template.lua
@@ -223,6 +223,7 @@ local template = {
                                                 '|=', '&=', '<<=', '>>=',
                                                 '||', '&&', '!', '!=',
                                                 'continue',
+                                                '|lambda|',
                                             }),
     ['Lua.runtime.plugin']                  = Type.Or(Type.String, Type.Array(Type.String)) ,
     ['Lua.runtime.pluginArgs']              = Type.Or(Type.Array(Type.String), Type.Hash(Type.String, Type.String)),


### PR DESCRIPTION
This pull request adds the `|lambda|` operator to the Lua.runtime.nonstandardSymbol configuration template, which allows the use of that option. Previously, support for it existed in the parser, but we could not actually use the option because it is not recognised in the configuration.