### PR TITLE
fix: don't return empty hover

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 
 * `FIX` adds the `|lambda|` operator to the `Lua.runtime.nonstandardSymbol` configuration template, which allows the use of that option. Previously, support for it existed in the parser, but we could not actually use the option because it is not recognised in the configuration.
 * `FIX` Typed `@field` (eg `---@field [string] boolean`) should not override other defined field [#2171](https://github.com/LuaLS/lua-language-server/issues/2171), [#2711](https://github.com/LuaLS/lua-language-server/issues/2711)
+* `FIX` don't return empty hover doc when luals failed to find definition
 
 ## 3.15.0
 `2025-6-25`

--- a/script/provider/provider.lua
+++ b/script/provider/provider.lua
@@ -369,9 +369,13 @@ m.register 'textDocument/hover' {
         if not hover or not source then
             return nil
         end
+        local value = tostring(hover)
+        if #value == 0 then
+            return nil
+        end
         return {
             contents = {
-                value = tostring(hover),
+                value = value,
                 kind  = 'markdown',
             },
             range = converter.packRange(state, source.start, source.finish),


### PR DESCRIPTION
Nvim show me an error(since: https://github.com/neovim/neovim/pull/34789), when I hover an symbol
whose definition cannot be found by luals
```
**/neovim/runtime/lua/vim/lsp/util.lua:1685: 'width' key must be a
positive Integer
```

To reprodunce, hover on a with this file
```lua
---@type a
```

Haven't reproduced with other lsp but I think it's harmless to PR here.
