### PR TITLE
fix: incorrect generation of function signatures with tuple parameters

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 <!-- Add all new changes here. They will be moved under a version at release -->
+* `FIX` Incorrect generation of function signatures with tuple-parameters
 * `FIX` Incorrect inject-field message for extra table field in exact class
 * `CHG` Rename configuration option `Lua.diagnostics.disableScheme` to `Lua.diagnostics.validScheme` and improve its description. Now it enables diagnostics for Lua files that use the specified scheme.
 * `FIX` adds the `|lambda|` operator to the `Lua.runtime.nonstandardSymbol` configuration template, which allows the use of that option. Previously, support for it existed in the parser, but we could not actually use the option because it is not recognised in the configuration.

--- a/script/core/signature.lua
+++ b/script/core/signature.lua
@@ -63,7 +63,11 @@ local function makeOneSignature(source, oop, index)
         : gsub('%b{}', function (str)
             return ('_'):rep(#str)
         end)
-        : gsub('[%[%]%(%)]', '_')
+        : gsub ('%b[]', function (str)
+            return ('_'):rep(#str)
+        end)
+        : gsub('[%(%)]', '_')
+
     for start, finish in converted:gmatch '%s*()[^,]+()' do
         i = i + 1
         params[i] = {

--- a/test/signature/init.lua
+++ b/test/signature/init.lua
@@ -235,6 +235,39 @@ end)(<??>)
 {'function (<!a: any!>, b: any)'}
 
 TEST [[
+---@param a [any, any]
+---@param b any
+function X(a, b) end
+
+X({ 1, 2 }, <?3?>)
+]]
+{
+'function X(a: [any, any], <!b: any!>)'
+}
+
+TEST [[
+---@param a any
+---@param b [any, any]
+---@param c any
+function X(a, b, c) end
+
+X(1, { 2, 3 }<??>, 4)
+]]
+{
+'function X(a: any, <!b: [any, any]!>, c: any)'
+}
+
+TEST [[
+---@param a [table<any>, {[1]:any,[2]:any}]
+function X(a) end
+
+X({ { 1 }, { 2, 3 } }<??>)
+]]
+{
+'function X(<!a: [table<any>, { [1]: any, [2]: any }]!>)'
+}
+
+TEST [[
 ---@overload fun()
 ---@overload fun(a:number)
 ---@param a number


### PR DESCRIPTION
[Tuple types](https://luals.github.io/wiki/annotations/#documenting-types) as function parameters are incorrectly parsed as multiple parameters when generating the function signature. This breaks highlighting for the currently active function parameter.

MWE, generated highlight denoted by `<...>`:
```lua
---@param a [any, any]
---@param b any
function X(a, b) end

X({ 1, 2 }|, 3)
-- expected: function X(<a: [any, any]>, b: any)
-- actual:   function X(<a: [any>, any], b: any)

X({ 1, 2 }, 3|)
-- expected: function X(a: [any, any], <b: any>)
-- actual:   function X(a: [any, <any]>, b: any)
```

Any square brackets are blindly replaced with `_` when generating the signature. This works for array types (e.g. `any[]`, which becomes `any__`), but breaks when scanning for the next parameter delimiter inside of tuples (e.g. `[any, any]`, which becomes `_any, any_`). Removing matching brackets via `%b[]` instead keeps the same behaviour for array types, but blanks out the entire tuple for tuple types (i.e. `[any, any]` becomes `__________`).

The only potential problem I see with this approach are dictionaries, which may also contain square brackets. These are substituted before attempting to match square brackets however, so this should not cause any issues.