### PR TITLE
Fix name-style provider not using URI when loading config

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 <!-- Add all new changes here. They will be moved under a version at release -->
+* `FIX` Fix initial `nameStyle.config` not getting loaded in the appropriate workspace.
 
 ## 3.18.2
 * `CHG` `duplicate-set-field` diagnostic now supports linked suppression: when any occurrence of a duplicate field is suppressed with `---@diagnostic disable` or `---@diagnostic disable-next-line`, all warnings for that field name will be suppressed

--- a/script/provider/name-style.lua
+++ b/script/provider/name-style.lua
@@ -11,7 +11,7 @@ m.loaded = false
 
 function m.nameStyleCheck(uri, text)
     if not m.loaded then
-        local value = config.get(nil, "Lua.nameStyle.config")
+        local value = config.get(uri, "Lua.nameStyle.config")
         codeFormat.update_name_style_config(value)
         m.loaded = true
     end


### PR DESCRIPTION
Currently, the initial `config.get` call for `Lua.nameStyle.config` does not use the provided URI. This results in the initial name style config to be `{}`, ignoring any settings overrides.

This PR provides a simple fix that uses the URI for the initial `config.get` call.
Tested in Zed with a `.luarc.json` file.

Fixes #2643.