### PR TITLE
fix `osdate` field types to match Lua manual

### DIFF
--- a/meta/template/os.lua
+++ b/meta/template/os.lua
@@ -11,23 +11,23 @@ function os.clock() end
 
 ---@class osdate:osdateparam
 ---#DES 'osdate.year'
----@field year  integer|string
+---@field year  integer
 ---#DES 'osdate.month'
----@field month integer|string
+---@field month integer
 ---#DES 'osdate.day'
----@field day   integer|string
+---@field day   integer
 ---#DES 'osdate.hour'
----@field hour  integer|string
+---@field hour  integer
 ---#DES 'osdate.min'
----@field min   integer|string
+---@field min   integer
 ---#DES 'osdate.sec'
----@field sec   integer|string
+---@field sec   integer
 ---#DES 'osdate.wday'
----@field wday  integer|string
+---@field wday  integer
 ---#DES 'osdate.yday'
----@field yday  integer|string
+---@field yday  integer
 ---#DES 'osdate.isdst'
----@field isdst boolean
+---@field isdst boolean?
 
 ---#DES 'os.date'
 ---@param format? string


### PR DESCRIPTION
`osdate` (return type of `os.date()`) fields are all integers (not `integer|string`), except for `isdst` which is `boolean` and may be absent if the information is not available. The `integer|string` union belongs on `osdateparam` (used by `os.time()`), not the return type.