### PR TITLE
Feature: Narrow overload candidates by preceding argument types

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 <!-- Add all new changes here. They will be moved under a version at release -->
+* `NEW` Narrow overload candidates by the types of the preceding arguments, for completion and `param-type-mismatch`
+  ```lua
+  ---@class A.Component
+  ---@class B.Component
+
+  ---@overload fun(c: A.Component, field: "hp"|"max_hp")
+  ---@overload fun(c: B.Component, field: "mana"|"cooldown")
+  local function setValue(...) end
+
+  ---@type A.Component
+  local a
+
+  setValue(a, "mana") --> now warns (`param-type-mismatch`); completion inside the quotes only suggests "hp" and "max_hp"
+  ```
 * `NEW` Support type inference for `@field` and `@type` function declarations in method overrides [#3367](https://github.com/LuaLS/lua-language-server/issues/3367)
 * `FIX` Deduplicate documentation bindings for parameters
 * `FIX` Correct `math.type` meta return annotation to use `nil` instead of the string literal `'nil'`

--- a/script/core/diagnostics/param-type-mismatch.lua
+++ b/script/core/diagnostics/param-type-mismatch.lua
@@ -66,15 +66,41 @@ local function getReceiverGenericMap(uri, source)
     return nil
 end
 
+---@param uri uri
 ---@param funcNode vm.node
+---@param callArgs parser.object[]
 ---@param i integer
----@param classGenericMap table<string, vm.node>?
----@return vm.node?
-local function getDefNode(funcNode, i, classGenericMap)
-    local defNode = vm.createNode()
+---@return parser.object[]
+local function getCheckableFunctions(uri, funcNode, callArgs, i)
+    local funcs = {}
     for src in funcNode:eachObject() do
         if src.type == 'function'
         or src.type == 'doc.type.function' then
+            funcs[#funcs+1] = src
+        end
+    end
+    if #funcs > 1 then
+        local matched = {}
+        for _, src in ipairs(funcs) do
+            if vm.isPriorArgsMatched(uri, src, callArgs, i) then
+                matched[#matched+1] = src
+            end
+        end
+        if #matched > 0 then
+            funcs = matched
+        end
+    end
+    return funcs
+end
+
+---@param funcs parser.object[]
+---@param i integer
+---@param classGenericMap table<string, vm.node>?
+---@return vm.node?
+local function getDefNode(funcs, i, classGenericMap)
+    local defNode = vm.createNode()
+    for _, src in ipairs(funcs) do
+        if src.args then
             local param = src.args and src.args[i]
             if param then
                 local paramNode = vm.compileNode(param)
@@ -108,14 +134,13 @@ local function getDefNode(funcNode, i, classGenericMap)
     return defNode
 end
 
----@param funcNode vm.node
+---@param funcs parser.object[]
 ---@param i integer
 ---@return vm.node
-local function getRawDefNode(funcNode, i)
+local function getRawDefNode(funcs, i)
     local defNode = vm.createNode()
-    for f in funcNode:eachObject() do
-        if f.type == 'function'
-        or f.type == 'doc.type.function' then
+    for _, f in ipairs(funcs) do
+        if f.args then
             local param = f.args and f.args[i]
             if param then
                 defNode:merge(vm.compileNode(param))
@@ -146,7 +171,8 @@ return function (uri, callback)
             if not refNode then
                 goto CONTINUE
             end
-            local defNode = getDefNode(funcNode, i, classGenericMap)
+            local funcs = getCheckableFunctions(uri, funcNode, source.args, i)
+            local defNode = getDefNode(funcs, i, classGenericMap)
             if not defNode then
                 goto CONTINUE
             end
@@ -159,7 +185,7 @@ return function (uri, callback)
             end
             local errs = {}
             if not vm.canCastType(uri, defNode, refNode, errs) then
-                local rawDefNode = getRawDefNode(funcNode, i)
+                local rawDefNode = getRawDefNode(funcs, i)
                 assert(errs)
                 callback {
                     start   = arg.start,

--- a/script/vm/compiler.lua
+++ b/script/vm/compiler.lua
@@ -1208,22 +1208,40 @@ local function compileCallArgNode(arg, call, callNode, fixIndex, myIndex)
         end
     end
 
+    local docFuncs = {}
     for n in callNode:eachObject() do
         if n.type == 'function' then
             ---@cast n parser.object
             dealFunction(n)
         elseif n.type == 'doc.type.function' then
             ---@cast n parser.object
-            dealDocFunc(n)
+            docFuncs[#docFuncs+1] = n
         elseif n.type == 'global' and n.cate == 'type' then
             ---@cast n vm.global
             local overloads = vm.getOverloadsByTypeName(n.name, guide.getUri(arg))
             if overloads then
                 for _, func in ipairs(overloads) do
-                    dealDocFunc(func)
+                    docFuncs[#docFuncs+1] = func
                 end
             end
         end
+    end
+
+    if #docFuncs > 1 and call.args then
+        local uri = guide.getUri(arg)
+        local matched = {}
+        for _, n in ipairs(docFuncs) do
+            if vm.isPriorArgsMatched(uri, n, call.args, myIndex, fixIndex) then
+                matched[#matched+1] = n
+            end
+        end
+        if #matched > 0 then
+            docFuncs = matched
+        end
+    end
+
+    for _, n in ipairs(docFuncs) do
+        dealDocFunc(n)
     end
 end
 

--- a/script/vm/function.lua
+++ b/script/vm/function.lua
@@ -353,6 +353,44 @@ local function isAllParamMatched(uri, args, params)
     return true
 end
 
+---@param param parser.object
+---@return boolean
+local function isVarargParam(param)
+    return param.type == '...'
+        or (param.name and param.name[1] == '...')
+end
+
+---@param uri uri
+---@param func parser.object -- `function` or `doc.type.function`
+---@param callArgs parser.object[]
+---@param myIndex integer
+---@param fixIndex? integer
+---@return boolean
+function vm.isPriorArgsMatched(uri, func, callArgs, myIndex, fixIndex)
+    fixIndex = fixIndex or 0
+    local params = func.args
+    if not params then
+        return true
+    end
+    for i = 1, myIndex - 1 do
+        local callArg = callArgs[i + fixIndex]
+        local param   = params[i]
+        if not callArg or not param then
+            break
+        end
+        if  callArg.type ~= '...'
+        and param.type ~= 'self'
+        and not isVarargParam(param) then
+            local defNode = vm.compileNode(param)
+            local refNode = vm.compileNode(callArg)
+            if not vm.canCastType(uri, defNode, refNode) then
+                return false
+            end
+        end
+    end
+    return true
+end
+
 ---@param uri uri
 ---@param args parser.object[]
 ---@param func parser.object

--- a/test/completion/common.lua
+++ b/test/completion/common.lua
@@ -4613,3 +4613,29 @@ print(a:<??>)
         kind  = define.CompletionItemKind.Method,
     },
 }
+
+TEST [[
+---@class A.Component
+---@class B.Component
+
+---@overload fun(c: A.Component, field: "hp"|"max_hp", value: any)
+---@overload fun(c: B.Component, field: "mana"|"cooldown", value: any)
+local function setValue(...) end
+
+---@type A.Component
+local a
+
+setValue(a, '<??>')
+]]
+{
+    {
+        label    = "'hp'",
+        kind     = define.CompletionItemKind.EnumMember,
+        textEdit = EXISTS,
+    },
+    {
+        label    = "'max_hp'",
+        kind     = define.CompletionItemKind.EnumMember,
+        textEdit = EXISTS,
+    },
+}

--- a/test/diagnostics/param-type-mismatch.lua
+++ b/test/diagnostics/param-type-mismatch.lua
@@ -395,3 +395,33 @@ f(x)
 ]]
 
 config.set(nil, 'Lua.type.checkTableShape', false)
+
+TEST [[
+---@class A.Component
+---@class B.Component
+
+---@overload fun(c: A.Component, field: "hp"|"max_hp")
+---@overload fun(c: B.Component, field: "mana"|"cooldown")
+local function setValue(...) end
+
+---@type A.Component
+local a
+
+setValue(a, 'hp')
+setValue(a, <!'mana'!>)
+]]
+
+TEST [[
+---@class A.Component
+---@class B.Component
+
+---@overload fun(c: A.Component, field: "hp")
+---@overload fun(c: B.Component, field: "mana")
+local function setValue(...) end
+
+---@type A.Component|B.Component
+local c
+
+setValue(c, 'hp')
+setValue(c, 'mana')
+]]


### PR DESCRIPTION
## Summary

Narrow LuaDoc overload candidates using the inferred types of arguments that precede the parameter being completed or checked.

This allows later parameter types to depend on an earlier class-typed argument, consistently across completion and `param-type-mismatch` diagnostics.

## Problem

Given overloads whose later parameters depend on the type of an earlier argument:

```lua
---@class A.Component
---@class B.Component

---@overload fun(c: A.Component, field: "hp"|"max_hp")
---@overload fun(c: B.Component, field: "mana"|"cooldown")
local function setValue(...) end

---@type A.Component
local a

setValue(a, "mana")
```

LuaLS previously combined the `field` types from every overload. Completion therefore suggested fields from both component types, and `"mana"` was accepted even though the first argument was `A.Component`.

## Changes

- Add a shared overload-matching helper that checks preceding arguments with `vm.canCastType`.
- Narrow LuaDoc overloads while compiling call-argument types for completion.
- Apply the same narrowing to `param-type-mismatch` diagnostics and diagnostic messages.
- Retain all candidates when narrowing produces no matches, so union or imprecise argument types preserve the previous behavior.
- Add completion and diagnostic regression tests.
- Add an Unreleased changelog entry.

With the example above, completion now only suggests `"hp"` and `"max_hp"`, and passing `"mana"` reports `param-type-mismatch`.

## Testing

- [x] Added completion coverage for class-dependent overloads.
- [x] Added diagnostic coverage for matching and mismatching fields.
- [x] Added coverage for ambiguous union arguments falling back to all overloads.
- [x] Ran the full test suite:

```console
./bin/lua-language-server.exe test.lua
...
test finish.
```