### PR TITLE
Dofile inference

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 <!-- Add all new changes here. They will be moved under a version at release -->
+* `NEW` Support type inference for `dofile` and add a new `Lua.workspace.dofileRoots` setting to configure where it reads from
 * `NEW` Support type inference for `@field` and `@type` function declarations in method overrides [#3367](https://github.com/LuaLS/lua-language-server/issues/3367)
 * `FIX` Deduplicate documentation bindings for parameters
 * `FIX` Correct `math.type` meta return annotation to use `nil` instead of the string literal `'nil'`

--- a/doc/en-us/config.md
+++ b/doc/en-us/config.md
@@ -14,6 +14,38 @@ boolean
 true
 ```
 
+# addonManager.repositoryBranch
+
+Specifies the git branch used by the addon manager.
+
+## type
+
+```ts
+string
+```
+
+## default
+
+```jsonc
+""
+```
+
+# addonManager.repositoryPath
+
+Specifies the git path used by the addon manager.
+
+## type
+
+```ts
+string
+```
+
+## default
+
+```jsonc
+""
+```
+
 # addonRepositoryPath
 
 Specifies the addon repository path (not related to the addon manager).
@@ -22,6 +54,12 @@ Specifies the addon repository path (not related to the addon manager).
 
 ```ts
 string
+```
+
+## default
+
+```jsonc
+""
 ```
 
 # codeLens.enable
@@ -132,6 +170,22 @@ string
 "Replace"
 ```
 
+# completion.maxSuggestCount
+
+Maximum number of fields to analyze for completions. When an object has more fields than this limit, completions will require more specific input to appear.
+
+## type
+
+```ts
+integer
+```
+
+## default
+
+```jsonc
+100
+```
+
 # completion.postfix
 
 The symbol used to trigger the postfix suggestion.
@@ -234,6 +288,7 @@ Array<string>
 * ``"ambiguity-1"``
 * ``"ambiguous-syntax"``
 * ``"args-after-dots"``
+* ``"assign-const-global"``
 * ``"assign-type-mismatch"``
 * ``"await-in-sync"``
 * ``"block-after-else"``
@@ -255,6 +310,7 @@ Array<string>
 * ``"duplicate-index"``
 * ``"duplicate-set-field"``
 * ``"empty-block"``
+* ``"env-is-global"``
 * ``"err-assign-as-eq"``
 * ``"err-c-long-comment"``
 * ``"err-comment-prefix"``
@@ -264,6 +320,7 @@ Array<string>
 * ``"err-nonstandard-symbol"``
 * ``"err-then-as-do"``
 * ``"exp-in-action"``
+* ``"global-close-attribute"``
 * ``"global-element"``
 * ``"global-in-nil-env"``
 * ``"incomplete-signature-doc"``
@@ -318,6 +375,7 @@ Array<string>
 * ``"missing-parameter"``
 * ``"missing-return"``
 * ``"missing-return-value"``
+* ``"multi-close"``
 * ``"name-style-check"``
 * ``"need-check-nil"``
 * ``"need-paren"``
@@ -347,6 +405,7 @@ Array<string>
 * ``"undefined-global"``
 * ``"unexpect-dots"``
 * ``"unexpect-efunc-name"``
+* ``"unexpect-gfunc-name"``
 * ``"unexpect-lfunc-name"``
 * ``"unexpect-symbol"``
 * ``"unicode-name"``
@@ -356,32 +415,18 @@ Array<string>
 * ``"unknown-operator"``
 * ``"unknown-symbol"``
 * ``"unreachable-code"``
+* ``"unsupport-named-vararg"``
 * ``"unsupport-symbol"``
 * ``"unused-function"``
 * ``"unused-label"``
 * ``"unused-local"``
 * ``"unused-vararg"``
+* ``"variable-not-declared"``
 
 ## default
 
 ```jsonc
 []
-```
-
-# diagnostics.disableScheme
-
-Do not diagnose Lua files that use the following scheme.
-
-## type
-
-```ts
-Array<string>
-```
-
-## default
-
-```jsonc
-["git"]
 ```
 
 # diagnostics.enable
@@ -398,6 +443,22 @@ boolean
 
 ```jsonc
 true
+```
+
+# diagnostics.enableScheme
+
+**Missing description!!**
+
+## type
+
+```ts
+Array<string>
+```
+
+## default
+
+```jsonc
+["file"]
 ```
 
 # diagnostics.globals
@@ -898,7 +959,7 @@ object<string, string>
     */
     "newfield-call": "Any",
     /*
-    Enable newline call diagnostics. Is's raised when a line starting with `(` is encountered, which is syntactically parsed as a function call on the previous line.
+    Enable newline call diagnostics. It's raised when a line starting with `(` is encountered, which is syntactically parsed as a function call on the previous line.
     */
     "newline-call": "Any",
     /*
@@ -1168,7 +1229,7 @@ object<string, string>
     */
     "newfield-call": "Warning",
     /*
-    Enable newline call diagnostics. Is's raised when a line starting with `(` is encountered, which is syntactically parsed as a function call on the previous line.
+    Enable newline call diagnostics. It's raised when a line starting with `(` is encountered, which is syntactically parsed as a function call on the previous line.
     */
     "newline-call": "Warning",
     /*
@@ -1396,6 +1457,43 @@ Array<string>
 []
 ```
 
+# doc.regengine
+
+The regular expression engine used for matching documentation scope names.
+
+## type
+
+```ts
+string
+```
+
+## enum
+
+* ``"glob"``: The default lightweight pattern syntax.
+* ``"lua"``: Full Lua-style regular expressions.
+
+## default
+
+```jsonc
+"glob"
+```
+
+# docScriptPath
+
+The regular expression engine used for matching documentation scope names.
+
+## type
+
+```ts
+string
+```
+
+## default
+
+```jsonc
+""
+```
+
 # format.defaultConfig
 
 The default format configuration. Has a lower priority than `.editorconfig` file in the workspace.
@@ -1466,6 +1564,22 @@ boolean
 
 ```jsonc
 true
+```
+
+# hint.awaitPropagate
+
+Enable the propagation of `await`. When a function calls a function marked `---@async`,it will be automatically marked as `---@async`.
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+false
 ```
 
 # hint.enable
@@ -1622,7 +1736,7 @@ integer
 ## default
 
 ```jsonc
-50
+10
 ```
 
 # hover.viewNumber
@@ -1673,6 +1787,38 @@ integer
 1000
 ```
 
+# language.completeAnnotation
+
+(VSCode only) Automatically insert "---@ " after a line break following a annotation.
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+true
+```
+
+# language.fixIndent
+
+(VSCode only) Fix incorrect auto-indentation, such as incorrect indentation when line breaks occur within a string containing the word "function".
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+true
+```
+
 # misc.executablePath
 
 Specify the executable path in VSCode.
@@ -1707,7 +1853,9 @@ Array<string>
 
 # nameStyle.config
 
-Set name style config
+Set name style config.
+Read [formatter docs](https://github.com/CppCXY/EmmyLuaCodeStyle/tree/master/docs) to learn usage.
+
 
 ## type
 
@@ -1890,13 +2038,13 @@ Plugin path. Please read [wiki](https://luals.github.io/wiki/plugins) to learn m
 ## type
 
 ```ts
-string
+string | array
 ```
 
 ## default
 
 ```jsonc
-""
+null
 ```
 
 # runtime.pluginArgs
@@ -1906,13 +2054,13 @@ Additional arguments for the plugin.
 ## type
 
 ```ts
-Array<string>
+array | object
 ```
 
 ## default
 
 ```jsonc
-[]
+null
 ```
 
 # runtime.special
@@ -1970,6 +2118,7 @@ string
 * ``"Lua 5.2"``
 * ``"Lua 5.3"``
 * ``"Lua 5.4"``
+* ``"Lua 5.5"``
 * ``"LuaJIT"``
 
 ## default
@@ -2090,6 +2239,74 @@ boolean
 true
 ```
 
+# type.checkTableShape
+
+Strictly check the shape of the table.
+
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+false
+```
+
+# type.inferParamType
+
+When a parameter type is not annotated, it is inferred from the function's call sites.
+
+When this setting is `false`, the type of the parameter is `any` when it is not annotated.
+
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+false
+```
+
+# type.inferTableSize
+
+Maximum number of table fields analyzed during type inference.
+
+## type
+
+```ts
+integer
+```
+
+## default
+
+```jsonc
+10
+```
+
+# type.maxUnionVariants
+
+**Missing description!!**
+
+## type
+
+```ts
+integer
+```
+
+## default
+
+```jsonc
+0
+```
+
 # type.weakNilCheck
 
 When checking the type of union type, ignore the `nil` in it.
@@ -2204,20 +2421,29 @@ Automatic detection and adaptation of third-party libraries, currently supported
 ## type
 
 ```ts
-string
+string | boolean
 ```
-
-## enum
-
-* ``"Ask"``
-* ``"Apply"``
-* ``"ApplyInMemory"``
-* ``"Disable"``
 
 ## default
 
 ```jsonc
-"Ask"
+null
+```
+
+# workspace.dofileRoots
+
+In addition to the current workspace, which directories `dofile` will treat as a possible root. The files in these directories will be loaded immediately.
+
+## type
+
+```ts
+Array<string>
+```
+
+## default
+
+```jsonc
+[]
 ```
 
 # workspace.ignoreDir

--- a/doc/es-419/config.md
+++ b/doc/es-419/config.md
@@ -1,0 +1,2563 @@
+# addonManager.enable
+
+Si el manejador de extensiones está habilitado.
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+true
+```
+
+# addonManager.repositoryBranch
+
+Especifica la rama de git usada por el manejador de extensiones.
+
+## type
+
+```ts
+string
+```
+
+## default
+
+```jsonc
+""
+```
+
+# addonManager.repositoryPath
+
+Especifica la ruta git usada por el manejador de extensiones.
+
+## type
+
+```ts
+string
+```
+
+## default
+
+```jsonc
+""
+```
+
+# addonRepositoryPath
+
+Especifica la ruta del repositorio de complementos (no relacionada con el gestor de complementos).
+
+## type
+
+```ts
+string
+```
+
+## default
+
+```jsonc
+""
+```
+
+# codeLens.enable
+
+Habilita el lente para código.
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+false
+```
+
+# completion.autoRequire
+
+Agrega automáticamente el `require` correspondiente cuando la entrada se parece a un nombre de archivo.
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+true
+```
+
+# completion.callSnippet
+
+Muestra snippets para llamadas de funciones.
+
+## type
+
+```ts
+string
+```
+
+## enum
+
+* ``"Disable"``: Solo muestra `función nombre`.
+* ``"Both"``: Muestra `función nombre` y `llamar al snippet`.
+* ``"Replace"``: Solo muestra `llamar al snippet`.
+
+## default
+
+```jsonc
+"Disable"
+```
+
+# completion.displayContext
+
+La prevista de la sugerencia del snippet de código relevante ayuda a entender el uso de la sugerenecia. El número fijado indica el número de líneas interceptadas en el fragmento de código. Fijando en `0` se deshabilita esta característica.
+
+## type
+
+```ts
+integer
+```
+
+## default
+
+```jsonc
+0
+```
+
+# completion.enable
+
+Habilita la completación.
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+true
+```
+
+# completion.keywordSnippet
+
+Muestra snippets con sintaxis de palabras clave.
+
+## type
+
+```ts
+string
+```
+
+## enum
+
+* ``"Disable"``: Solo muestra `palabra clave`.
+* ``"Both"``: Muestra `palabra clave` y `snippet de sintaxis`.
+* ``"Replace"``: Solo muestra `snippet de sintaxis`.
+
+## default
+
+```jsonc
+"Replace"
+```
+
+# completion.maxSuggestCount
+
+Número máximo de campos a analizar para autocompletar. Cuando un objeto tiene más campos que este límite, las sugerencias requerirán una entrada más específica para aparecer.
+
+## type
+
+```ts
+integer
+```
+
+## default
+
+```jsonc
+100
+```
+
+# completion.postfix
+
+El símbolo usado para lanzar la sugerencia posfija.
+
+## type
+
+```ts
+string
+```
+
+## default
+
+```jsonc
+"@"
+```
+
+# completion.requireSeparator
+
+Separador usado en `require`.
+
+## type
+
+```ts
+string
+```
+
+## default
+
+```jsonc
+"."
+```
+
+# completion.showParams
+
+Muestra los parámetros en la lista de completado. Cuando la función tiene múltiples definiciones, se mostrarán por separado.
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+true
+```
+
+# completion.showWord
+
+Muestra palabras contextuales en las sugerencias.
+
+## type
+
+```ts
+string
+```
+
+## enum
+
+* ``"Enable"``: Siempre muestra palabras contextuales en las sugerencias.
+* ``"Fallback"``: Las palabras contextuales solo se muestran si las sugerencias basadas en la semántica no están provistas.
+* ``"Disable"``: Sin presentar las palabras contextuales.
+
+## default
+
+```jsonc
+"Fallback"
+```
+
+# completion.workspaceWord
+
+Si es que el la palabra contextual presentada contiene contenido de otros archivos en el espacio de trabajo.
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+true
+```
+
+# diagnostics.disable
+
+Deshabilita los diagnósticos (Usa código en corchetes bajo el cursor).
+
+## type
+
+```ts
+Array<string>
+```
+
+## enum
+
+* ``"action-after-return"``
+* ``"ambiguity-1"``
+* ``"ambiguous-syntax"``
+* ``"args-after-dots"``
+* ``"assign-const-global"``
+* ``"assign-type-mismatch"``
+* ``"await-in-sync"``
+* ``"block-after-else"``
+* ``"break-outside"``
+* ``"cast-local-type"``
+* ``"cast-type-mismatch"``
+* ``"circle-doc-class"``
+* ``"close-non-object"``
+* ``"code-after-break"``
+* ``"codestyle-check"``
+* ``"count-down-loop"``
+* ``"deprecated"``
+* ``"different-requires"``
+* ``"discard-returns"``
+* ``"doc-field-no-class"``
+* ``"duplicate-doc-alias"``
+* ``"duplicate-doc-field"``
+* ``"duplicate-doc-param"``
+* ``"duplicate-index"``
+* ``"duplicate-set-field"``
+* ``"empty-block"``
+* ``"env-is-global"``
+* ``"err-assign-as-eq"``
+* ``"err-c-long-comment"``
+* ``"err-comment-prefix"``
+* ``"err-do-as-then"``
+* ``"err-eq-as-assign"``
+* ``"err-esc"``
+* ``"err-nonstandard-symbol"``
+* ``"err-then-as-do"``
+* ``"exp-in-action"``
+* ``"global-close-attribute"``
+* ``"global-element"``
+* ``"global-in-nil-env"``
+* ``"incomplete-signature-doc"``
+* ``"index-in-func-name"``
+* ``"inject-field"``
+* ``"invisible"``
+* ``"jump-local-scope"``
+* ``"keyword"``
+* ``"local-limit"``
+* ``"lowercase-global"``
+* ``"lua-doc-miss-sign"``
+* ``"luadoc-error-diag-mode"``
+* ``"luadoc-miss-alias-extends"``
+* ``"luadoc-miss-alias-name"``
+* ``"luadoc-miss-arg-name"``
+* ``"luadoc-miss-cate-name"``
+* ``"luadoc-miss-class-extends-name"``
+* ``"luadoc-miss-class-name"``
+* ``"luadoc-miss-diag-mode"``
+* ``"luadoc-miss-diag-name"``
+* ``"luadoc-miss-field-extends"``
+* ``"luadoc-miss-field-name"``
+* ``"luadoc-miss-fun-after-overload"``
+* ``"luadoc-miss-generic-name"``
+* ``"luadoc-miss-local-name"``
+* ``"luadoc-miss-module-name"``
+* ``"luadoc-miss-operator-name"``
+* ``"luadoc-miss-param-extends"``
+* ``"luadoc-miss-param-name"``
+* ``"luadoc-miss-see-name"``
+* ``"luadoc-miss-sign-name"``
+* ``"luadoc-miss-symbol"``
+* ``"luadoc-miss-type-name"``
+* ``"luadoc-miss-vararg-type"``
+* ``"luadoc-miss-version"``
+* ``"malformed-number"``
+* ``"miss-end"``
+* ``"miss-esc-x"``
+* ``"miss-exp"``
+* ``"miss-exponent"``
+* ``"miss-field"``
+* ``"miss-loop-max"``
+* ``"miss-loop-min"``
+* ``"miss-method"``
+* ``"miss-name"``
+* ``"miss-sep-in-table"``
+* ``"miss-space-between"``
+* ``"miss-symbol"``
+* ``"missing-fields"``
+* ``"missing-global-doc"``
+* ``"missing-local-export-doc"``
+* ``"missing-parameter"``
+* ``"missing-return"``
+* ``"missing-return-value"``
+* ``"multi-close"``
+* ``"name-style-check"``
+* ``"need-check-nil"``
+* ``"need-paren"``
+* ``"nesting-long-mark"``
+* ``"newfield-call"``
+* ``"newline-call"``
+* ``"no-unknown"``
+* ``"no-visible-label"``
+* ``"not-yieldable"``
+* ``"param-type-mismatch"``
+* ``"redefined-label"``
+* ``"redefined-local"``
+* ``"redundant-parameter"``
+* ``"redundant-return"``
+* ``"redundant-return-value"``
+* ``"redundant-value"``
+* ``"return-type-mismatch"``
+* ``"set-const"``
+* ``"spell-check"``
+* ``"trailing-space"``
+* ``"unbalanced-assignments"``
+* ``"undefined-doc-class"``
+* ``"undefined-doc-name"``
+* ``"undefined-doc-param"``
+* ``"undefined-env-child"``
+* ``"undefined-field"``
+* ``"undefined-global"``
+* ``"unexpect-dots"``
+* ``"unexpect-efunc-name"``
+* ``"unexpect-gfunc-name"``
+* ``"unexpect-lfunc-name"``
+* ``"unexpect-symbol"``
+* ``"unicode-name"``
+* ``"unknown-attribute"``
+* ``"unknown-cast-variable"``
+* ``"unknown-diag-code"``
+* ``"unknown-operator"``
+* ``"unknown-symbol"``
+* ``"unreachable-code"``
+* ``"unsupport-named-vararg"``
+* ``"unsupport-symbol"``
+* ``"unused-function"``
+* ``"unused-label"``
+* ``"unused-local"``
+* ``"unused-vararg"``
+* ``"variable-not-declared"``
+
+## default
+
+```jsonc
+[]
+```
+
+# diagnostics.enable
+
+Habilita los diagnósticos.
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+true
+```
+
+# diagnostics.enableScheme
+
+**Missing description!!**
+
+## type
+
+```ts
+Array<string>
+```
+
+## default
+
+```jsonc
+["file"]
+```
+
+# diagnostics.globals
+
+Variables globales definidas.
+
+## type
+
+```ts
+Array<string>
+```
+
+## default
+
+```jsonc
+[]
+```
+
+# diagnostics.globalsRegex
+
+Encuentra variables globales definidas usando esta expresión regular.
+
+## type
+
+```ts
+Array<string>
+```
+
+## default
+
+```jsonc
+[]
+```
+
+# diagnostics.groupFileStatus
+
+Modifica los diagnósticos de archivos requeridos en un grupo.
+
+* Opened:  solo diagnostica los archivos abiertos
+* Any:     diagnostica todos los archivos
+* None:    deshabilita este diagnóstico
+
+`Fallback` significa que los diagnósticos en este grupo son controlados con una severida separada de `diagnostics.neededFileStatus`.
+Otras configuraciones descartan las configuraciones individuales que no terminen en `!`.
+
+
+## type
+
+```ts
+object<string, string>
+```
+
+## enum
+
+* ``"Any"``
+* ``"Opened"``
+* ``"None"``
+* ``"Fallback"``
+
+## default
+
+```jsonc
+{
+    /*
+    * ambiguity-1
+    * count-down-loop
+    * different-requires
+    * newfield-call
+    * newline-call
+    */
+    "ambiguity": "Fallback",
+    /*
+    * await-in-sync
+    * not-yieldable
+    */
+    "await": "Fallback",
+    /*
+    * codestyle-check
+    * name-style-check
+    * spell-check
+    */
+    "codestyle": "Fallback",
+    /*
+    * global-element
+    */
+    "conventions": "Fallback",
+    /*
+    * duplicate-index
+    * duplicate-set-field
+    */
+    "duplicate": "Fallback",
+    /*
+    * global-in-nil-env
+    * lowercase-global
+    * undefined-env-child
+    * undefined-global
+    */
+    "global": "Fallback",
+    /*
+    * circle-doc-class
+    * doc-field-no-class
+    * duplicate-doc-alias
+    * duplicate-doc-field
+    * duplicate-doc-param
+    * incomplete-signature-doc
+    * missing-global-doc
+    * missing-local-export-doc
+    * undefined-doc-class
+    * undefined-doc-name
+    * undefined-doc-param
+    * unknown-cast-variable
+    * unknown-diag-code
+    * unknown-operator
+    */
+    "luadoc": "Fallback",
+    /*
+    * redefined-local
+    */
+    "redefined": "Fallback",
+    /*
+    * close-non-object
+    * deprecated
+    * discard-returns
+    * invisible
+    */
+    "strict": "Fallback",
+    /*
+    * no-unknown
+    */
+    "strong": "Fallback",
+    /*
+    * assign-type-mismatch
+    * cast-local-type
+    * cast-type-mismatch
+    * inject-field
+    * need-check-nil
+    * param-type-mismatch
+    * return-type-mismatch
+    * undefined-field
+    */
+    "type-check": "Fallback",
+    /*
+    * missing-fields
+    * missing-parameter
+    * missing-return
+    * missing-return-value
+    * redundant-parameter
+    * redundant-return-value
+    * redundant-value
+    * unbalanced-assignments
+    */
+    "unbalanced": "Fallback",
+    /*
+    * code-after-break
+    * empty-block
+    * redundant-return
+    * trailing-space
+    * unreachable-code
+    * unused-function
+    * unused-label
+    * unused-local
+    * unused-vararg
+    */
+    "unused": "Fallback"
+}
+```
+
+# diagnostics.groupSeverity
+
+Modifica el la severirad de los diagnósticos en un grupo.
+`Fallback` significa que los diagnósticos en este grupo son controlados con una severida separada de `diagnostics.severity`.
+Otras configuraciones descartan las configuraciones individuales que no terminen en `!`.
+
+
+## type
+
+```ts
+object<string, string>
+```
+
+## enum
+
+* ``"Error"``
+* ``"Warning"``
+* ``"Information"``
+* ``"Hint"``
+* ``"Fallback"``
+
+## default
+
+```jsonc
+{
+    /*
+    * ambiguity-1
+    * count-down-loop
+    * different-requires
+    * newfield-call
+    * newline-call
+    */
+    "ambiguity": "Fallback",
+    /*
+    * await-in-sync
+    * not-yieldable
+    */
+    "await": "Fallback",
+    /*
+    * codestyle-check
+    * name-style-check
+    * spell-check
+    */
+    "codestyle": "Fallback",
+    /*
+    * global-element
+    */
+    "conventions": "Fallback",
+    /*
+    * duplicate-index
+    * duplicate-set-field
+    */
+    "duplicate": "Fallback",
+    /*
+    * global-in-nil-env
+    * lowercase-global
+    * undefined-env-child
+    * undefined-global
+    */
+    "global": "Fallback",
+    /*
+    * circle-doc-class
+    * doc-field-no-class
+    * duplicate-doc-alias
+    * duplicate-doc-field
+    * duplicate-doc-param
+    * incomplete-signature-doc
+    * missing-global-doc
+    * missing-local-export-doc
+    * undefined-doc-class
+    * undefined-doc-name
+    * undefined-doc-param
+    * unknown-cast-variable
+    * unknown-diag-code
+    * unknown-operator
+    */
+    "luadoc": "Fallback",
+    /*
+    * redefined-local
+    */
+    "redefined": "Fallback",
+    /*
+    * close-non-object
+    * deprecated
+    * discard-returns
+    * invisible
+    */
+    "strict": "Fallback",
+    /*
+    * no-unknown
+    */
+    "strong": "Fallback",
+    /*
+    * assign-type-mismatch
+    * cast-local-type
+    * cast-type-mismatch
+    * inject-field
+    * need-check-nil
+    * param-type-mismatch
+    * return-type-mismatch
+    * undefined-field
+    */
+    "type-check": "Fallback",
+    /*
+    * missing-fields
+    * missing-parameter
+    * missing-return
+    * missing-return-value
+    * redundant-parameter
+    * redundant-return-value
+    * redundant-value
+    * unbalanced-assignments
+    */
+    "unbalanced": "Fallback",
+    /*
+    * code-after-break
+    * empty-block
+    * redundant-return
+    * trailing-space
+    * unreachable-code
+    * unused-function
+    * unused-label
+    * unused-local
+    * unused-vararg
+    */
+    "unused": "Fallback"
+}
+```
+
+# diagnostics.ignoredFiles
+
+Cómo diagnosticar los archivos ignorados.
+
+## type
+
+```ts
+string
+```
+
+## enum
+
+* ``"Enable"``: Estos archivos siempre se diagnostican.
+* ``"Opened"``: Estos archivos se diagnostican solo cuando se abren.
+* ``"Disable"``: Estos archivos no se diagnostican.
+
+## default
+
+```jsonc
+"Opened"
+```
+
+# diagnostics.libraryFiles
+
+Cómo diagnosticar los archivos cargados via `Lua.workspace.library`.
+
+## type
+
+```ts
+string
+```
+
+## enum
+
+* ``"Enable"``: Estos archivos siempre se diagnostican.
+* ``"Opened"``: Estos archivos se diagnostican solo cuando se abren.
+* ``"Disable"``: Estos archivos no se diagnostican.
+
+## default
+
+```jsonc
+"Opened"
+```
+
+# diagnostics.neededFileStatus
+
+* Opened:  Solo diagnostica los archivos abiertos
+* Any:     diagnostica todos los archivos
+* None:    deshabilita este diagnóstico
+
+Agregue `!` al final para descartar la configuración `diagnostics.groupFileStatus`.
+
+
+## type
+
+```ts
+object<string, string>
+```
+
+## enum
+
+* ``"Any"``
+* ``"Opened"``
+* ``"None"``
+* ``"Any!"``
+* ``"Opened!"``
+* ``"None!"``
+
+## default
+
+```jsonc
+{
+    /*
+    Habilita el diagnóstico de precedencia de operadores ambiguos. Por ejemplo, ante la expresión `num or 0 + 1` se sugerirrá `(num or 0) + 1`.
+    */
+    "ambiguity-1": "Any",
+    /*
+    Habilita el diagnóstico para asignaciones en las cuales el valor del tipo no calza con el tipo de la variable siendo asignada.
+    */
+    "assign-type-mismatch": "Opened",
+    /*
+    Habilita el diagnóstico para llamadas a funciones asíncronas dentro de una función síncrona.
+    */
+    "await-in-sync": "None",
+    /*
+    Habilita el diagnóstico para conversión de tipos de variables locales donde el tipo objetivo no calza con el tipo definido.
+    */
+    "cast-local-type": "Opened",
+    /*
+    Habilita el diagnóstico para conversiones de tipos donde el tipo objetivo no calza con el tipo inicial.
+    */
+    "cast-type-mismatch": "Opened",
+    "circle-doc-class": "Any",
+    /*
+    Habilita el diagnóstico para intentos de cerra una variable con un no-objeto.
+    */
+    "close-non-object": "Any",
+    /*
+    Habilita el diagnóstico para el código que viene después de un `break` en un bucle.
+    */
+    "code-after-break": "Opened",
+    /*
+    Habilita el diagnóstico para líneas formateadas incorrectamente.
+    */
+    "codestyle-check": "None",
+    /*
+    Habilita el diagnóstico para bucles `for` en los cuales nunca se alcanza su máximo o límite por que el bucle es incremental en vez de decremental.
+    */
+    "count-down-loop": "Any",
+    /*
+    Habilita el diagnóstico para resaltar APIs obsoletas.
+    */
+    "deprecated": "Any",
+    /*
+    Habilita el diagnóstico para archivos que son requeridos con dos rutas distintas.
+    */
+    "different-requires": "Any",
+    /*
+    Habilita el diagnóstico para llamadas de funciones anotadas con `---@nodiscard` en las cuales se ignore los valores retornados.
+    */
+    "discard-returns": "Any",
+    /*
+    Habilita el diagnóstico para resaltar una anotación de campo sin una anotación de clase que lo defina.
+    */
+    "doc-field-no-class": "Any",
+    /*
+    Habilita el diagnóstico para nombres de alias duplicados en una anotación.
+    */
+    "duplicate-doc-alias": "Any",
+    /*
+    Habilita el diagnóstico para nombres de campo duplicados en una anotación.
+    */
+    "duplicate-doc-field": "Any",
+    /*
+    Habilita el diagnóstico para nombres de parámetros duplicados en una anotación.
+    */
+    "duplicate-doc-param": "Any",
+    /*
+    Habilita el diagnóstico de índices de tabla duplicados.
+    */
+    "duplicate-index": "Any",
+    /*
+    Habilita el diagnóstico para cuando se asigna el mismo campo en una clase más de una vez.
+    */
+    "duplicate-set-field": "Opened",
+    /*
+    Habilita el diagnóstico de bloques de código vacíos.
+    */
+    "empty-block": "Opened",
+    /*
+    Habilita el diagnóstico que alerta sobre elementos globales.
+    */
+    "global-element": "None",
+    /*
+    Habilita el diagnóstico para la prohibición de uso de variables globales (`_ENV` se fija a `nil`).
+    */
+    "global-in-nil-env": "Any",
+    /*
+    Habilita el diagnóstico para anotaciones @param o @return incompletas para funciones.
+    */
+    "incomplete-signature-doc": "None",
+    "inject-field": "Opened",
+    /*
+    Habilita el diagnóstico para accesos a campos que son invisibles.
+    */
+    "invisible": "Any",
+    /*
+    Habilita el diagnóstico de definiciones de variables globacels con minúsculas.
+    */
+    "lowercase-global": "Any",
+    "missing-fields": "Any",
+    /*
+    Habilita el diagnóstico para globales faltantes. Las funciones globales deben tener un comentario y anotaciones para todos sus parámetros y valores retornados.
+    */
+    "missing-global-doc": "None",
+    /*
+    Habilita el diagnóstico para locales exportadas. Las funciones locales deben tener un comentario y anotaciones para todos sus parámetros y valores retornados.
+    */
+    "missing-local-export-doc": "None",
+    /*
+    Habilita el diagnóstico para llamados de funciones donde el número de argumentos es menore que el número de parámetros anotados de la función.
+    */
+    "missing-parameter": "Any",
+    /*
+    Habilita el diagnóstico para para funciones con anotaciones de retorno que no tienen la expresión `return …`.
+    */
+    "missing-return": "Any",
+    /*
+    Habilita el diagnóstico para expresiones `return …` sin valores aunque la función que la contiene declare retornos.
+    */
+    "missing-return-value": "Any",
+    /*
+    Habilita el diagnóstico para el estilo de nombres.
+    */
+    "name-style-check": "None",
+    /*
+    Habilita el diagnóstico para usos de variables si `nil` o un valor opcional (potencialmente `nil`) haya sido asignado a la variable anteriormente.
+    */
+    "need-check-nil": "Opened",
+    /*
+    Habilita el diagnóstico de campo nuevo en una llamada. Se alza un error cuando los paréntesis de una llamada a una función aparecen en la siguiente línea cuando se define un campo en una tabla.
+    */
+    "newfield-call": "Any",
+    /*
+    Habilita el diagnóstico de llamadas en línea nueva. Se alza un error en las líneas que comienzan con `(`, lo que se lee sintácticamente como una llamada a la línea anterior.
+    */
+    "newline-call": "Any",
+    /*
+    Habilita el diagnóstico para los casos en que el tipo no puede ser inferido.
+    */
+    "no-unknown": "None",
+    /*
+    Habilita el diagnóstico para llamadas a `coroutine.yield()` cuando no esté permitido.
+    */
+    "not-yieldable": "None",
+    /*
+    Habilita el diagnóstico para llamadas a funciones donde el tipo de un parámetro provisto no calza con el tipo de la definición anotado de la función.
+    */
+    "param-type-mismatch": "Opened",
+    /*
+    Habilita el diagnóstico de variables locals redefinidas.
+    */
+    "redefined-local": "Opened",
+    /*
+    Habilita el diagnóstico de parámetros redundantes de una función.
+    */
+    "redundant-parameter": "Any",
+    /*
+    Habilita el diagnóstico para sentencias de retorno que no son necesarias porque la función terminaría de igual manera.
+    */
+    "redundant-return": "Opened",
+    /*
+    Habilita el diagnóstico para sentencias de retorno que retornan un valor extra que no fue especificado por una anotación de retorno.
+    */
+    "redundant-return-value": "Any",
+    /*
+    Habilita el diagnóstico de valores asignados redundantemente. Se alza un error en una asignación, cuando el número de valores es mayor que el número de objetos a los cuales se les asigna.
+    */
+    "redundant-value": "Any",
+    /*
+    Habilita el diagnóstico para valores retornados cuyo tipo no calza con el tipo declarado en la anotación correspondiente de la función.
+    */
+    "return-type-mismatch": "Opened",
+    /*
+    Habilita el diagnóstico para errores tipográficos en strings.
+    */
+    "spell-check": "None",
+    /*
+    Habilita el diagnóstico de espacios al final de línea.
+    */
+    "trailing-space": "Opened",
+    /*
+    Habilita el diagnóstico para asignaciones múltiplies si no todas las variables obtienen un valor (por ejemplo, `local x,y = 1`).
+    */
+    "unbalanced-assignments": "Any",
+    /*
+    Habilita el diagnóstico para las anotaciones de clase en las cuales una clase sin definir es referenciada.
+    */
+    "undefined-doc-class": "Any",
+    /*
+    Habilita el diagnóstico para anotaciones de tipo que referencian a un tipo o alias sin definir.
+    */
+    "undefined-doc-name": "Any",
+    /*
+    Habilita el diagnóstico para casos en que una anotación de parámetro es dado sin declarar el parámetro en la definición de la función.
+    */
+    "undefined-doc-param": "Any",
+    /*
+    Habilita el diagnóstico de variables de ambientes sin definir. Se alza un error cuando a la tabla `_ENV` se le asigna una tabla literal nueva, pero la variable global usada no está presente en el ambiente global.
+    */
+    "undefined-env-child": "Any",
+    /*
+    Habilita el diagnóstico para los casos en que se lee un campo sin definir de una variable.
+    */
+    "undefined-field": "Opened",
+    /*
+    Habilita el diagnóstico de variables globales sin definir.
+    */
+    "undefined-global": "Any",
+    /*
+    Habilita el diagnóstico para conversiones de tipo de variables sin definir.
+    */
+    "unknown-cast-variable": "Any",
+    /*
+    Habilita el diagnóstico para los casos en que un código desconocido de diagnóstico es ingresado.
+    */
+    "unknown-diag-code": "Any",
+    /*
+    Habilita el diagnóstico para operadores desconocidos.
+    */
+    "unknown-operator": "Any",
+    /*
+    Habilita el diagnóstico para código inalcanzable.
+    */
+    "unreachable-code": "Opened",
+    /*
+    Habilita el diagnóstico funcines sin uso.
+    */
+    "unused-function": "Opened",
+    /*
+    Habilita el diagnóstico de etiquetas sin uso.
+    */
+    "unused-label": "Opened",
+    /*
+    Habilita el diagnóstico de variables local sin uso.
+    */
+    "unused-local": "Opened",
+    /*
+    Habilita el diagnóstico de expresión de número variable de argumentos (vararg) sin uso.
+    */
+    "unused-vararg": "Opened"
+}
+```
+
+# diagnostics.severity
+
+Modifica el la severirad de los diagnósticos.
+
+Agregue `!` al final para descartar la configuración `diagnostics.groupSeverity`.
+
+
+## type
+
+```ts
+object<string, string>
+```
+
+## enum
+
+* ``"Error"``
+* ``"Warning"``
+* ``"Information"``
+* ``"Hint"``
+* ``"Error!"``
+* ``"Warning!"``
+* ``"Information!"``
+* ``"Hint!"``
+
+## default
+
+```jsonc
+{
+    /*
+    Habilita el diagnóstico de precedencia de operadores ambiguos. Por ejemplo, ante la expresión `num or 0 + 1` se sugerirrá `(num or 0) + 1`.
+    */
+    "ambiguity-1": "Warning",
+    /*
+    Habilita el diagnóstico para asignaciones en las cuales el valor del tipo no calza con el tipo de la variable siendo asignada.
+    */
+    "assign-type-mismatch": "Warning",
+    /*
+    Habilita el diagnóstico para llamadas a funciones asíncronas dentro de una función síncrona.
+    */
+    "await-in-sync": "Warning",
+    /*
+    Habilita el diagnóstico para conversión de tipos de variables locales donde el tipo objetivo no calza con el tipo definido.
+    */
+    "cast-local-type": "Warning",
+    /*
+    Habilita el diagnóstico para conversiones de tipos donde el tipo objetivo no calza con el tipo inicial.
+    */
+    "cast-type-mismatch": "Warning",
+    "circle-doc-class": "Warning",
+    /*
+    Habilita el diagnóstico para intentos de cerra una variable con un no-objeto.
+    */
+    "close-non-object": "Warning",
+    /*
+    Habilita el diagnóstico para el código que viene después de un `break` en un bucle.
+    */
+    "code-after-break": "Hint",
+    /*
+    Habilita el diagnóstico para líneas formateadas incorrectamente.
+    */
+    "codestyle-check": "Warning",
+    /*
+    Habilita el diagnóstico para bucles `for` en los cuales nunca se alcanza su máximo o límite por que el bucle es incremental en vez de decremental.
+    */
+    "count-down-loop": "Warning",
+    /*
+    Habilita el diagnóstico para resaltar APIs obsoletas.
+    */
+    "deprecated": "Warning",
+    /*
+    Habilita el diagnóstico para archivos que son requeridos con dos rutas distintas.
+    */
+    "different-requires": "Warning",
+    /*
+    Habilita el diagnóstico para llamadas de funciones anotadas con `---@nodiscard` en las cuales se ignore los valores retornados.
+    */
+    "discard-returns": "Warning",
+    /*
+    Habilita el diagnóstico para resaltar una anotación de campo sin una anotación de clase que lo defina.
+    */
+    "doc-field-no-class": "Warning",
+    /*
+    Habilita el diagnóstico para nombres de alias duplicados en una anotación.
+    */
+    "duplicate-doc-alias": "Warning",
+    /*
+    Habilita el diagnóstico para nombres de campo duplicados en una anotación.
+    */
+    "duplicate-doc-field": "Warning",
+    /*
+    Habilita el diagnóstico para nombres de parámetros duplicados en una anotación.
+    */
+    "duplicate-doc-param": "Warning",
+    /*
+    Habilita el diagnóstico de índices de tabla duplicados.
+    */
+    "duplicate-index": "Warning",
+    /*
+    Habilita el diagnóstico para cuando se asigna el mismo campo en una clase más de una vez.
+    */
+    "duplicate-set-field": "Warning",
+    /*
+    Habilita el diagnóstico de bloques de código vacíos.
+    */
+    "empty-block": "Hint",
+    /*
+    Habilita el diagnóstico que alerta sobre elementos globales.
+    */
+    "global-element": "Warning",
+    /*
+    Habilita el diagnóstico para la prohibición de uso de variables globales (`_ENV` se fija a `nil`).
+    */
+    "global-in-nil-env": "Warning",
+    /*
+    Habilita el diagnóstico para anotaciones @param o @return incompletas para funciones.
+    */
+    "incomplete-signature-doc": "Warning",
+    "inject-field": "Warning",
+    /*
+    Habilita el diagnóstico para accesos a campos que son invisibles.
+    */
+    "invisible": "Warning",
+    /*
+    Habilita el diagnóstico de definiciones de variables globacels con minúsculas.
+    */
+    "lowercase-global": "Information",
+    "missing-fields": "Warning",
+    /*
+    Habilita el diagnóstico para globales faltantes. Las funciones globales deben tener un comentario y anotaciones para todos sus parámetros y valores retornados.
+    */
+    "missing-global-doc": "Warning",
+    /*
+    Habilita el diagnóstico para locales exportadas. Las funciones locales deben tener un comentario y anotaciones para todos sus parámetros y valores retornados.
+    */
+    "missing-local-export-doc": "Warning",
+    /*
+    Habilita el diagnóstico para llamados de funciones donde el número de argumentos es menore que el número de parámetros anotados de la función.
+    */
+    "missing-parameter": "Warning",
+    /*
+    Habilita el diagnóstico para para funciones con anotaciones de retorno que no tienen la expresión `return …`.
+    */
+    "missing-return": "Warning",
+    /*
+    Habilita el diagnóstico para expresiones `return …` sin valores aunque la función que la contiene declare retornos.
+    */
+    "missing-return-value": "Warning",
+    /*
+    Habilita el diagnóstico para el estilo de nombres.
+    */
+    "name-style-check": "Warning",
+    /*
+    Habilita el diagnóstico para usos de variables si `nil` o un valor opcional (potencialmente `nil`) haya sido asignado a la variable anteriormente.
+    */
+    "need-check-nil": "Warning",
+    /*
+    Habilita el diagnóstico de campo nuevo en una llamada. Se alza un error cuando los paréntesis de una llamada a una función aparecen en la siguiente línea cuando se define un campo en una tabla.
+    */
+    "newfield-call": "Warning",
+    /*
+    Habilita el diagnóstico de llamadas en línea nueva. Se alza un error en las líneas que comienzan con `(`, lo que se lee sintácticamente como una llamada a la línea anterior.
+    */
+    "newline-call": "Warning",
+    /*
+    Habilita el diagnóstico para los casos en que el tipo no puede ser inferido.
+    */
+    "no-unknown": "Warning",
+    /*
+    Habilita el diagnóstico para llamadas a `coroutine.yield()` cuando no esté permitido.
+    */
+    "not-yieldable": "Warning",
+    /*
+    Habilita el diagnóstico para llamadas a funciones donde el tipo de un parámetro provisto no calza con el tipo de la definición anotado de la función.
+    */
+    "param-type-mismatch": "Warning",
+    /*
+    Habilita el diagnóstico de variables locals redefinidas.
+    */
+    "redefined-local": "Hint",
+    /*
+    Habilita el diagnóstico de parámetros redundantes de una función.
+    */
+    "redundant-parameter": "Warning",
+    /*
+    Habilita el diagnóstico para sentencias de retorno que no son necesarias porque la función terminaría de igual manera.
+    */
+    "redundant-return": "Hint",
+    /*
+    Habilita el diagnóstico para sentencias de retorno que retornan un valor extra que no fue especificado por una anotación de retorno.
+    */
+    "redundant-return-value": "Warning",
+    /*
+    Habilita el diagnóstico de valores asignados redundantemente. Se alza un error en una asignación, cuando el número de valores es mayor que el número de objetos a los cuales se les asigna.
+    */
+    "redundant-value": "Warning",
+    /*
+    Habilita el diagnóstico para valores retornados cuyo tipo no calza con el tipo declarado en la anotación correspondiente de la función.
+    */
+    "return-type-mismatch": "Warning",
+    /*
+    Habilita el diagnóstico para errores tipográficos en strings.
+    */
+    "spell-check": "Information",
+    /*
+    Habilita el diagnóstico de espacios al final de línea.
+    */
+    "trailing-space": "Hint",
+    /*
+    Habilita el diagnóstico para asignaciones múltiplies si no todas las variables obtienen un valor (por ejemplo, `local x,y = 1`).
+    */
+    "unbalanced-assignments": "Warning",
+    /*
+    Habilita el diagnóstico para las anotaciones de clase en las cuales una clase sin definir es referenciada.
+    */
+    "undefined-doc-class": "Warning",
+    /*
+    Habilita el diagnóstico para anotaciones de tipo que referencian a un tipo o alias sin definir.
+    */
+    "undefined-doc-name": "Warning",
+    /*
+    Habilita el diagnóstico para casos en que una anotación de parámetro es dado sin declarar el parámetro en la definición de la función.
+    */
+    "undefined-doc-param": "Warning",
+    /*
+    Habilita el diagnóstico de variables de ambientes sin definir. Se alza un error cuando a la tabla `_ENV` se le asigna una tabla literal nueva, pero la variable global usada no está presente en el ambiente global.
+    */
+    "undefined-env-child": "Information",
+    /*
+    Habilita el diagnóstico para los casos en que se lee un campo sin definir de una variable.
+    */
+    "undefined-field": "Warning",
+    /*
+    Habilita el diagnóstico de variables globales sin definir.
+    */
+    "undefined-global": "Warning",
+    /*
+    Habilita el diagnóstico para conversiones de tipo de variables sin definir.
+    */
+    "unknown-cast-variable": "Warning",
+    /*
+    Habilita el diagnóstico para los casos en que un código desconocido de diagnóstico es ingresado.
+    */
+    "unknown-diag-code": "Warning",
+    /*
+    Habilita el diagnóstico para operadores desconocidos.
+    */
+    "unknown-operator": "Warning",
+    /*
+    Habilita el diagnóstico para código inalcanzable.
+    */
+    "unreachable-code": "Hint",
+    /*
+    Habilita el diagnóstico funcines sin uso.
+    */
+    "unused-function": "Hint",
+    /*
+    Habilita el diagnóstico de etiquetas sin uso.
+    */
+    "unused-label": "Hint",
+    /*
+    Habilita el diagnóstico de variables local sin uso.
+    */
+    "unused-local": "Hint",
+    /*
+    Habilita el diagnóstico de expresión de número variable de argumentos (vararg) sin uso.
+    */
+    "unused-vararg": "Hint"
+}
+```
+
+# diagnostics.unusedLocalExclude
+
+Las variables que calcen con el siguiente patrón no se diagnostican con `unused-local`.
+
+## type
+
+```ts
+Array<string>
+```
+
+## default
+
+```jsonc
+[]
+```
+
+# diagnostics.workspaceDelay
+
+Latencia en milisegundos para diagnósticos del espacio de trabajo.
+
+## type
+
+```ts
+integer
+```
+
+## default
+
+```jsonc
+3000
+```
+
+# diagnostics.workspaceEvent
+
+Fija el tiempo para lanzar los diagnósticos del espacio de trabajo.
+
+## type
+
+```ts
+string
+```
+
+## enum
+
+* ``"OnChange"``: Lanza los diagnósticos del espacio de trabajo cuando se cambie el archivo.
+* ``"OnSave"``: Lanza los diagnósticos del espacio de trabajo cuando se guarde el archivo.
+* ``"None"``: Deshabilita los diagnósticos del espacio de trabajo.
+
+## default
+
+```jsonc
+"OnSave"
+```
+
+# diagnostics.workspaceRate
+
+Tasa porcentual de diagnósticos del espacio de trabajo. Decremente este valor para reducir el uso de CPU, también reduciendo la velocidad de los diagnósticos del espacio de trabajo. El diagnóstico del archivo que esté editando siempre se hace a toda velocidad y no es afectado por esta configuración.
+
+## type
+
+```ts
+integer
+```
+
+## default
+
+```jsonc
+100
+```
+
+# doc.packageName
+
+Trata los nombres específicos de campo como del paquete. Por ejemplo `m_*` significa `XXX.m_id` y `XXX.m_tipo` son de paquete, por lo que solo pueden ser accedidos en el archivo donde son definidos.
+
+## type
+
+```ts
+Array<string>
+```
+
+## default
+
+```jsonc
+[]
+```
+
+# doc.privateName
+
+Trata los nombres específicos de campo como privados. Por ejemplo `m_*` significa `XXX.m_id` y `XXX.m_tipo` son privados, por lo que solo pueden ser accedidos donde se define la clase.
+
+## type
+
+```ts
+Array<string>
+```
+
+## default
+
+```jsonc
+[]
+```
+
+# doc.protectedName
+
+Trata los nombres específicos de campo como protegidos. Por ejemplo `m_*` significa `XXX.m_id` y `XXX.m_tipo` son privados, por lo que solo pueden ser accedidos donde se define la clase y sus subclases.
+
+## type
+
+```ts
+Array<string>
+```
+
+## default
+
+```jsonc
+[]
+```
+
+# doc.regengine
+
+Motor de expresiones regulares usado para coincidir nombres de ámbito de documentación.
+
+## type
+
+```ts
+string
+```
+
+## enum
+
+* ``"glob"``: Sintaxis de patrones ligera predeterminada.
+* ``"lua"``: Expresiones regulares completas al estilo Lua.
+
+## default
+
+```jsonc
+"glob"
+```
+
+# docScriptPath
+
+Motor de expresiones regulares usado para coincidir nombres de ámbito de documentación.
+
+## type
+
+```ts
+string
+```
+
+## default
+
+```jsonc
+""
+```
+
+# format.defaultConfig
+
+La configuración de formateo predeterminada. Tiene menor prioridad que el archivo `.editorconfig`
+en el espacio de trabajo.
+Revise [la documentación del formateador](https://github.com/CppCXY/EmmyLuaCodeStyle/tree/master/docs)
+para aprender más sobre su uso.
+
+
+## type
+
+```ts
+Object<string, string>
+```
+
+## default
+
+```jsonc
+{}
+```
+
+# format.enable
+
+Habilita el formateador de código.
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+true
+```
+
+# hint.arrayIndex
+
+Muestra las pistas de los índices de arreglos cuando se construye una tabla.
+
+## type
+
+```ts
+string
+```
+
+## enum
+
+* ``"Enable"``: Muestra las pistas en todas las tablas.
+* ``"Auto"``: Muestra las pistas solo cuando la tabla tiene más de 3 ítemes, o cuando la tabla es mixta.
+* ``"Disable"``: Deshabilita las pistas en de los índices de arreglos.
+
+## default
+
+```jsonc
+"Auto"
+```
+
+# hint.await
+
+Si la función que se llama está marcada con `---@async`, pregunta por un `await` en la llamada.
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+true
+```
+
+# hint.awaitPropagate
+
+Habilita la propagación de `await`. Cuando una función llama a una función marcada con `---@async`,se marcará automáticamente como `---@async`.
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+false
+```
+
+# hint.enable
+
+Habilita pistas en línea.
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+false
+```
+
+# hint.paramName
+
+Muestra las pistas de tipo en las llamadas a funciones.
+
+## type
+
+```ts
+string
+```
+
+## enum
+
+* ``"All"``: Se muestran odos los tipos de los parámetros.
+* ``"Literal"``: Se muestran solo los parámetros de tipos literales.
+* ``"Disable"``: Deshabilita las pistas de los parámetros.
+
+## default
+
+```jsonc
+"All"
+```
+
+# hint.paramType
+
+Muestra las pistas de tipo al parámetro de las funciones.
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+true
+```
+
+# hint.semicolon
+
+Si no hay punto y coma al final de la sentencia, despliega un punto y coma virtual.
+
+## type
+
+```ts
+string
+```
+
+## enum
+
+* ``"All"``: Todas las sentencias con un punto y coma virtual desplegado.
+* ``"SameLine"``: Cuando dos sentencias están en la misma línea, despliega un punto y coma entre ellas.
+* ``"Disable"``: Deshabilita punto y coma virtuales.
+
+## default
+
+```jsonc
+"SameLine"
+```
+
+# hint.setType
+
+Muestra las pistas de tipo en las asignación.
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+false
+```
+
+# hover.enable
+
+Habilita la información bajo el cursor.
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+true
+```
+
+# hover.enumsLimit
+
+Cuando el valor corresponde a múltiples tipos, fija el límite de tipos en despliegue.
+
+## type
+
+```ts
+integer
+```
+
+## default
+
+```jsonc
+5
+```
+
+# hover.expandAlias
+
+Expandir o no los alias. Por ejemplo, la expansión de `---@alias miTipo boolean|number` aparece como `boolean|number`, caso contrarior, aparece como `miTipo`.
+
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+true
+```
+
+# hover.previewFields
+
+Cuando se ubica el cursor para ver una tabla, fija el máximo numero de previstas para los campos.
+
+## type
+
+```ts
+integer
+```
+
+## default
+
+```jsonc
+10
+```
+
+# hover.viewNumber
+
+Ubica el cursor para ver el contenido numérico (solo si el literal no es decimal).
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+true
+```
+
+# hover.viewString
+
+Ubica el cursor bajo un string para ver su contenido (solo si el literal contiene un caracter de escape).
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+true
+```
+
+# hover.viewStringMax
+
+Largo máximo de la información bajo el cursor para ver el contenido de un string.
+
+## type
+
+```ts
+integer
+```
+
+## default
+
+```jsonc
+1000
+```
+
+# language.completeAnnotation
+
+(Solo en VSCode) Inserta automáticamente un "---@ " después de un quiebre de línea que sucede a una anotación.
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+true
+```
+
+# language.fixIndent
+
+(Solo en VSCode) Arregla la auto-indentación incorrecta, como aquella cuando los quiebres de línea ocurren dentro de un string que contengan la palabra "function".
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+true
+```
+
+# misc.executablePath
+
+Especifica la ruta del ejecutable en VSCode.
+
+## type
+
+```ts
+string
+```
+
+## default
+
+```jsonc
+""
+```
+
+# misc.parameters
+
+[Parámetros de la línea de comando](https://github.com/LuaLS/lua-telemetry-server/tree/master/method) para iniciar el servidor de lenguage en VSCode.
+
+## type
+
+```ts
+Array<string>
+```
+
+## default
+
+```jsonc
+[]
+```
+
+# nameStyle.config
+
+Configuración de estilo para nombres.
+Revise [la documentación del formateador](https://github.com/CppCXY/EmmyLuaCodeStyle/tree/master/docs)
+para aprender más sobre su uso.
+
+
+## type
+
+```ts
+Object<string, string | array>
+```
+
+## default
+
+```jsonc
+{}
+```
+
+# runtime.builtin
+
+Ajuste de la habilitación de biblioteca interna provista. Puede deshabilitar (o redefinir) las bibliotecas inexistentes de acuerdo al ambiente de ejecución.
+
+* `default`: Indica que la biblioteca será habilitada o deshabilitada de acuerdo a la versión que se ejecuta.
+* `enable`: Habilitada
+* `disable`: Deshabilitada
+
+
+## type
+
+```ts
+object<string, string>
+```
+
+## enum
+
+* ``"default"``
+* ``"enable"``
+* ``"disable"``
+
+## default
+
+```jsonc
+{
+    "basic": "default",
+    "bit": "default",
+    "bit32": "default",
+    "builtin": "default",
+    "coroutine": "default",
+    "debug": "default",
+    "ffi": "default",
+    "io": "default",
+    "jit": "default",
+    "jit.profile": "default",
+    "jit.util": "default",
+    "math": "default",
+    "os": "default",
+    "package": "default",
+    "string": "default",
+    "string.buffer": "default",
+    "table": "default",
+    "table.clear": "default",
+    "table.new": "default",
+    "utf8": "default"
+}
+```
+
+# runtime.fileEncoding
+
+Codificación de archivo. La opción `ansi` solo está disponible en la plataforma `Windows`.
+
+## type
+
+```ts
+string
+```
+
+## enum
+
+* ``"utf8"``
+* ``"ansi"``
+* ``"utf16le"``
+* ``"utf16be"``
+
+## default
+
+```jsonc
+"utf8"
+```
+
+# runtime.meta
+
+Formato del nombre del directoria de los archivos meta.
+
+## type
+
+```ts
+string
+```
+
+## default
+
+```jsonc
+"${version} ${language} ${encoding}"
+```
+
+# runtime.nonstandardSymbol
+
+Soporte de símbolos no estándar. Asegúrese que la versión de Lua que se ejecuta soporte estos símbolos.
+
+## type
+
+```ts
+Array<string>
+```
+
+## enum
+
+* ``"//"``
+* ``"/**/"``
+* ``"`"``
+* ``"+="``
+* ``"-="``
+* ``"*="``
+* ``"/="``
+* ``"%="``
+* ``"^="``
+* ``"//="``
+* ``"|="``
+* ``"&="``
+* ``"<<="``
+* ``">>="``
+* ``"||"``
+* ``"&&"``
+* ``"!"``
+* ``"!="``
+* ``"continue"``
+* ``"|lambda|"``
+
+## default
+
+```jsonc
+[]
+```
+
+# runtime.path
+
+Cuando se ocupa un `require`, cómo se encuentra el archivo basado en el nombre de entrada.
+
+Asignar esta configuración a `?/init.lua` significa que cuando se ingresa `require 'myfile'` se busca en `${workspace}/myfile/init.lua` desde los archivos cargados.
+Si `runtime.pathStrict` es `false`, también se busca en `${workspace}/**/myfile/init.lua`.
+Si se desea cargar archivos fuera del espacio de trabajo, se debe asignar `Lua.workspace.library` primero.
+
+
+## type
+
+```ts
+Array<string>
+```
+
+## default
+
+```jsonc
+["?.lua","?/init.lua"]
+```
+
+# runtime.pathStrict
+
+Cuando está habilitado, `runtime.path` sólo buscará en el primer nivel de directorios, vea la descripción de `runtime.path`.
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+false
+```
+
+# runtime.plugin
+
+Ruta de plugin. Revise [la wiki](https://luals.github.io/wiki/plugins) para más información.
+
+## type
+
+```ts
+string | array
+```
+
+## default
+
+```jsonc
+null
+```
+
+# runtime.pluginArgs
+
+Argumentos adicionals al plugin.
+
+## type
+
+```ts
+array | object
+```
+
+## default
+
+```jsonc
+null
+```
+
+# runtime.special
+
+Las variables globales personalizadas son consideradas variables intrínsecas, y el servidor de lenguage proveerá un soporte especial.
+El siguiente ejemplo muestra que 'include' es tratado como 'require'.
+```json
+"Lua.runtime.special" : {
+    "include" : "require"
+}
+```
+
+
+## type
+
+```ts
+Object<string, string>
+```
+
+## default
+
+```jsonc
+{}
+```
+
+# runtime.unicodeName
+
+Se permiten los caracteres unicode en los nombres.
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+false
+```
+
+# runtime.version
+
+Versión de Lua que se ejecuta.
+
+## type
+
+```ts
+string
+```
+
+## enum
+
+* ``"Lua 5.1"``
+* ``"Lua 5.2"``
+* ``"Lua 5.3"``
+* ``"Lua 5.4"``
+* ``"Lua 5.5"``
+* ``"LuaJIT"``
+
+## default
+
+```jsonc
+"Lua 5.4"
+```
+
+# semantic.annotation
+
+Coloración de las anotaciones de tipo.
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+true
+```
+
+# semantic.enable
+
+Habilita la coloración semántica. Puede ser necesario asignar `editor.semanticHighlighting.enabled`  a `true` para que tenga efecto.
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+true
+```
+
+# semantic.keyword
+
+Coloración semántica de palabras clave, literales y operadores. Se necesita habilitar esta característica si su editor no puede hacer coloración sintáctica.
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+false
+```
+
+# semantic.variable
+
+Coloración semántica de variables, campos y parámetros.
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+true
+```
+
+# signatureHelp.enable
+
+Habilita la ayuda de firma.
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+true
+```
+
+# spell.dict
+
+Palabras extra para el corrector ortográfico.
+
+## type
+
+```ts
+Array<string>
+```
+
+## default
+
+```jsonc
+[]
+```
+
+# type.castNumberToInteger
+
+Se permite asignar el tipo "número" al tipo "entero".
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+true
+```
+
+# type.checkTableShape
+
+Chequea estrictamente la forma de la tabla.
+
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+false
+```
+
+# type.inferParamType
+
+Cuando un tipo de parámetro no está anotado, se infiere su tipo de los lugares donde la función es llamada.
+
+Cuando esta configuración es `false`, el tipo del parámetro `any` cuando no puede ser anotado.
+
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+false
+```
+
+# type.inferTableSize
+
+Cantidad máxima de campos de tabla analizados durante la inferencia de tipos.
+
+## type
+
+```ts
+integer
+```
+
+## default
+
+```jsonc
+10
+```
+
+# type.maxUnionVariants
+
+**Missing description!!**
+
+## type
+
+```ts
+integer
+```
+
+## default
+
+```jsonc
+0
+```
+
+# type.weakNilCheck
+
+Cuando se revisa el tipo de un tipo de unión, los `nil` dentro son ignorados.
+
+Cuando esta configuración es `false`, el tipo `number|nil` no puede ser asignado al tipo `number`. Solo se puede con `true`.
+
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+false
+```
+
+# type.weakUnionCheck
+
+Una vez que un sub-tipo de un tipo de unión satisface la condición, el tipo de unión también satisface la condición.
+
+Cuando esta configuración es `false`, el tipo `number|boolean` no puede ser asignado al tipo `number`. Solo se puede con `true`.
+
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+false
+```
+
+# typeFormat.config
+
+Configura el comportamiento del formateo mientras se tipea código Lua.
+
+## type
+
+```ts
+object<string, string>
+```
+
+## default
+
+```jsonc
+{
+    /*
+    Controla si se completa automáticamente con `end` en las posiciones correspondientes.
+    */
+    "auto_complete_end": "true",
+    /*
+    Controla si se agrega automáticamente un separador al final de la declaración de una tabla.
+    */
+    "auto_complete_table_sep": "true",
+    /*
+    Controla si una línea se formatea
+    */
+    "format_line": "true"
+}
+```
+
+# window.progressBar
+
+Muestra la barra de progreso en la barra de estado.
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+true
+```
+
+# window.statusBar
+
+Muestra el estado de la extensión en la barra de estado.
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+true
+```
+
+# workspace.checkThirdParty
+
+Detección y adaptación automática de bibliotecas externas. Actualmente soportadas:
+
+* OpenResty
+* Cocos4.0
+* LÖVE
+* LÖVR
+* skynet
+* Jass
+
+
+## type
+
+```ts
+string | boolean
+```
+
+## default
+
+```jsonc
+null
+```
+
+# workspace.dofileRoots
+
+In addition to the current workspace, which directories `dofile` will treat as a possible root. The files in these directories will be loaded immediately.
+
+## type
+
+```ts
+Array<string>
+```
+
+## default
+
+```jsonc
+[]
+```
+
+# workspace.ignoreDir
+
+Directorios y archivos ignorados (se usa la misma gramática que en `.gitignore`)
+
+## type
+
+```ts
+Array<string>
+```
+
+## default
+
+```jsonc
+[".vscode"]
+```
+
+# workspace.ignoreSubmodules
+
+Ignora submódulos.
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+true
+```
+
+# workspace.library
+
+Además de los del espacio de trabajo actual, se cargan archivos de estos directorios. Los archivos en estos directorios serán tratados como bibliotecas con código externo y algunas características (como renombrar campos) no modificarán estos archivos.
+
+## type
+
+```ts
+Array<string>
+```
+
+## default
+
+```jsonc
+[]
+```
+
+# workspace.maxPreload
+
+Máxima pre-carga de archivos.
+
+## type
+
+```ts
+integer
+```
+
+## default
+
+```jsonc
+5000
+```
+
+# workspace.preloadFileSize
+
+Cuando se pre-carga, se omiten los archivos más grandes que este valor (en KB).
+
+## type
+
+```ts
+integer
+```
+
+## default
+
+```jsonc
+500
+```
+
+# workspace.useGitIgnore
+
+Ignora los archivos enlistados en `gitignore` .
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+true
+```
+
+# workspace.userThirdParty
+
+Rutas archivos de configuración para bibliotecas externas privadas. Revise [el archivo de configuración](https://github.com/LuaLS/lua-language-server/tree/master/meta/3rd) provisto.
+
+## type
+
+```ts
+Array<string>
+```
+
+## default
+
+```jsonc
+[]
+```

--- a/doc/ja-jp/config.md
+++ b/doc/ja-jp/config.md
@@ -1,0 +1,2559 @@
+# addonManager.enable
+
+アドオンマネージャーを有効にするかどうか。
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+true
+```
+
+# addonManager.repositoryBranch
+
+アドオンマネージャーが使用するgitブランチを指定します。
+
+## type
+
+```ts
+string
+```
+
+## default
+
+```jsonc
+""
+```
+
+# addonManager.repositoryPath
+
+アドオンマネージャーが使用するgitパスを指定します。
+
+## type
+
+```ts
+string
+```
+
+## default
+
+```jsonc
+""
+```
+
+# addonRepositoryPath
+
+アドオンのリポジトリパスを指定します（アドオンマネージャーとは無関係です）。
+
+## type
+
+```ts
+string
+```
+
+## default
+
+```jsonc
+""
+```
+
+# codeLens.enable
+
+コードレンズを有効にします。
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+false
+```
+
+# completion.autoRequire
+
+入力がファイル名のように見える場合、自動的にこのファイルを`require`します。
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+true
+```
+
+# completion.callSnippet
+
+関数呼び出しスニペットを表示します。
+
+## type
+
+```ts
+string
+```
+
+## enum
+
+* ``"Disable"``: 関数名のみを表示します。
+* ``"Both"``: 関数名と呼び出しスニペットを表示します。
+* ``"Replace"``: 呼び出しスニペットのみを表示します。
+
+## default
+
+```jsonc
+"Disable"
+```
+
+# completion.displayContext
+
+提案の関連コードスニペットをプレビューすることで、提案の使用法を理解しやすくなります。設定された数値は、コードフラグメント内で切り取られる行数を示します。`0`に設定すると、この機能を無効にできます。
+
+## type
+
+```ts
+integer
+```
+
+## default
+
+```jsonc
+0
+```
+
+# completion.enable
+
+補完を有効にします。
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+true
+```
+
+# completion.keywordSnippet
+
+キーワード構文スニペットを表示します。
+
+## type
+
+```ts
+string
+```
+
+## enum
+
+* ``"Disable"``: キーワードのみを表示します。
+* ``"Both"``: キーワードと構文スニペットを表示します。
+* ``"Replace"``: 構文スニペットのみを表示します。
+
+## default
+
+```jsonc
+"Replace"
+```
+
+# completion.maxSuggestCount
+
+補完用に分析するフィールドの最大数。オブジェクトがこの制限より多くのフィールドを持つ場合、補完が表示されるにはより具体的な入力が必要になります。
+
+## type
+
+```ts
+integer
+```
+
+## default
+
+```jsonc
+100
+```
+
+# completion.postfix
+
+後置提案をトリガーするために使用されるシンボル。
+
+## type
+
+```ts
+string
+```
+
+## default
+
+```jsonc
+"@"
+```
+
+# completion.requireSeparator
+
+`require`時に使用される区切り文字。
+
+## type
+
+```ts
+string
+```
+
+## default
+
+```jsonc
+"."
+```
+
+# completion.showParams
+
+補完リストにパラメータを表示します。関数に複数の定義がある場合、個別に表示されます。
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+true
+```
+
+# completion.showWord
+
+提案内にコンテキストワードを表示します。
+
+## type
+
+```ts
+string
+```
+
+## enum
+
+* ``"Enable"``: 常に提案内にコンテキストワードを表示します。
+* ``"Fallback"``: セマンティックスに基づく提案を提供できない場合のみ、コンテキストワードを表示します。
+* ``"Disable"``: コンテキストワードを表示しません。
+
+## default
+
+```jsonc
+"Fallback"
+```
+
+# completion.workspaceWord
+
+表示されるコンテキストワードにワークスペース内の他のファイルの内容を含めるかどうか。
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+true
+```
+
+# diagnostics.disable
+
+無効化する診断（ホバーの括弧内に表示されるコードを使用）。
+
+## type
+
+```ts
+Array<string>
+```
+
+## enum
+
+* ``"action-after-return"``
+* ``"ambiguity-1"``
+* ``"ambiguous-syntax"``
+* ``"args-after-dots"``
+* ``"assign-const-global"``
+* ``"assign-type-mismatch"``
+* ``"await-in-sync"``
+* ``"block-after-else"``
+* ``"break-outside"``
+* ``"cast-local-type"``
+* ``"cast-type-mismatch"``
+* ``"circle-doc-class"``
+* ``"close-non-object"``
+* ``"code-after-break"``
+* ``"codestyle-check"``
+* ``"count-down-loop"``
+* ``"deprecated"``
+* ``"different-requires"``
+* ``"discard-returns"``
+* ``"doc-field-no-class"``
+* ``"duplicate-doc-alias"``
+* ``"duplicate-doc-field"``
+* ``"duplicate-doc-param"``
+* ``"duplicate-index"``
+* ``"duplicate-set-field"``
+* ``"empty-block"``
+* ``"env-is-global"``
+* ``"err-assign-as-eq"``
+* ``"err-c-long-comment"``
+* ``"err-comment-prefix"``
+* ``"err-do-as-then"``
+* ``"err-eq-as-assign"``
+* ``"err-esc"``
+* ``"err-nonstandard-symbol"``
+* ``"err-then-as-do"``
+* ``"exp-in-action"``
+* ``"global-close-attribute"``
+* ``"global-element"``
+* ``"global-in-nil-env"``
+* ``"incomplete-signature-doc"``
+* ``"index-in-func-name"``
+* ``"inject-field"``
+* ``"invisible"``
+* ``"jump-local-scope"``
+* ``"keyword"``
+* ``"local-limit"``
+* ``"lowercase-global"``
+* ``"lua-doc-miss-sign"``
+* ``"luadoc-error-diag-mode"``
+* ``"luadoc-miss-alias-extends"``
+* ``"luadoc-miss-alias-name"``
+* ``"luadoc-miss-arg-name"``
+* ``"luadoc-miss-cate-name"``
+* ``"luadoc-miss-class-extends-name"``
+* ``"luadoc-miss-class-name"``
+* ``"luadoc-miss-diag-mode"``
+* ``"luadoc-miss-diag-name"``
+* ``"luadoc-miss-field-extends"``
+* ``"luadoc-miss-field-name"``
+* ``"luadoc-miss-fun-after-overload"``
+* ``"luadoc-miss-generic-name"``
+* ``"luadoc-miss-local-name"``
+* ``"luadoc-miss-module-name"``
+* ``"luadoc-miss-operator-name"``
+* ``"luadoc-miss-param-extends"``
+* ``"luadoc-miss-param-name"``
+* ``"luadoc-miss-see-name"``
+* ``"luadoc-miss-sign-name"``
+* ``"luadoc-miss-symbol"``
+* ``"luadoc-miss-type-name"``
+* ``"luadoc-miss-vararg-type"``
+* ``"luadoc-miss-version"``
+* ``"malformed-number"``
+* ``"miss-end"``
+* ``"miss-esc-x"``
+* ``"miss-exp"``
+* ``"miss-exponent"``
+* ``"miss-field"``
+* ``"miss-loop-max"``
+* ``"miss-loop-min"``
+* ``"miss-method"``
+* ``"miss-name"``
+* ``"miss-sep-in-table"``
+* ``"miss-space-between"``
+* ``"miss-symbol"``
+* ``"missing-fields"``
+* ``"missing-global-doc"``
+* ``"missing-local-export-doc"``
+* ``"missing-parameter"``
+* ``"missing-return"``
+* ``"missing-return-value"``
+* ``"multi-close"``
+* ``"name-style-check"``
+* ``"need-check-nil"``
+* ``"need-paren"``
+* ``"nesting-long-mark"``
+* ``"newfield-call"``
+* ``"newline-call"``
+* ``"no-unknown"``
+* ``"no-visible-label"``
+* ``"not-yieldable"``
+* ``"param-type-mismatch"``
+* ``"redefined-label"``
+* ``"redefined-local"``
+* ``"redundant-parameter"``
+* ``"redundant-return"``
+* ``"redundant-return-value"``
+* ``"redundant-value"``
+* ``"return-type-mismatch"``
+* ``"set-const"``
+* ``"spell-check"``
+* ``"trailing-space"``
+* ``"unbalanced-assignments"``
+* ``"undefined-doc-class"``
+* ``"undefined-doc-name"``
+* ``"undefined-doc-param"``
+* ``"undefined-env-child"``
+* ``"undefined-field"``
+* ``"undefined-global"``
+* ``"unexpect-dots"``
+* ``"unexpect-efunc-name"``
+* ``"unexpect-gfunc-name"``
+* ``"unexpect-lfunc-name"``
+* ``"unexpect-symbol"``
+* ``"unicode-name"``
+* ``"unknown-attribute"``
+* ``"unknown-cast-variable"``
+* ``"unknown-diag-code"``
+* ``"unknown-operator"``
+* ``"unknown-symbol"``
+* ``"unreachable-code"``
+* ``"unsupport-named-vararg"``
+* ``"unsupport-symbol"``
+* ``"unused-function"``
+* ``"unused-label"``
+* ``"unused-local"``
+* ``"unused-vararg"``
+* ``"variable-not-declared"``
+
+## default
+
+```jsonc
+[]
+```
+
+# diagnostics.enable
+
+診断を有効にします。
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+true
+```
+
+# diagnostics.enableScheme
+
+**Missing description!!**
+
+## type
+
+```ts
+Array<string>
+```
+
+## default
+
+```jsonc
+["file"]
+```
+
+# diagnostics.globals
+
+定義済みのグローバル変数。
+
+## type
+
+```ts
+Array<string>
+```
+
+## default
+
+```jsonc
+[]
+```
+
+# diagnostics.globalsRegex
+
+正規表現で定義済みのグローバル変数を検索します。
+
+## type
+
+```ts
+Array<string>
+```
+
+## default
+
+```jsonc
+[]
+```
+
+# diagnostics.groupFileStatus
+
+グループ内の診断対象ファイル状態を変更します。
+
+* Opened: 開いているファイルのみを診断
+* Any:    すべてのファイルを診断
+* None:   この診断を無効化
+
+`Fallback` は、このグループ内の診断が個別に `diagnostics.neededFileStatus` によって制御されることを意味します。
+その他の設定は、末尾に `!` が付いていない個別の設定を上書きします。
+
+
+## type
+
+```ts
+object<string, string>
+```
+
+## enum
+
+* ``"Any"``
+* ``"Opened"``
+* ``"None"``
+* ``"Fallback"``
+
+## default
+
+```jsonc
+{
+    /*
+    * ambiguity-1
+    * count-down-loop
+    * different-requires
+    * newfield-call
+    * newline-call
+    */
+    "ambiguity": "Fallback",
+    /*
+    * await-in-sync
+    * not-yieldable
+    */
+    "await": "Fallback",
+    /*
+    * codestyle-check
+    * name-style-check
+    * spell-check
+    */
+    "codestyle": "Fallback",
+    /*
+    * global-element
+    */
+    "conventions": "Fallback",
+    /*
+    * duplicate-index
+    * duplicate-set-field
+    */
+    "duplicate": "Fallback",
+    /*
+    * global-in-nil-env
+    * lowercase-global
+    * undefined-env-child
+    * undefined-global
+    */
+    "global": "Fallback",
+    /*
+    * circle-doc-class
+    * doc-field-no-class
+    * duplicate-doc-alias
+    * duplicate-doc-field
+    * duplicate-doc-param
+    * incomplete-signature-doc
+    * missing-global-doc
+    * missing-local-export-doc
+    * undefined-doc-class
+    * undefined-doc-name
+    * undefined-doc-param
+    * unknown-cast-variable
+    * unknown-diag-code
+    * unknown-operator
+    */
+    "luadoc": "Fallback",
+    /*
+    * redefined-local
+    */
+    "redefined": "Fallback",
+    /*
+    * close-non-object
+    * deprecated
+    * discard-returns
+    * invisible
+    */
+    "strict": "Fallback",
+    /*
+    * no-unknown
+    */
+    "strong": "Fallback",
+    /*
+    * assign-type-mismatch
+    * cast-local-type
+    * cast-type-mismatch
+    * inject-field
+    * need-check-nil
+    * param-type-mismatch
+    * return-type-mismatch
+    * undefined-field
+    */
+    "type-check": "Fallback",
+    /*
+    * missing-fields
+    * missing-parameter
+    * missing-return
+    * missing-return-value
+    * redundant-parameter
+    * redundant-return-value
+    * redundant-value
+    * unbalanced-assignments
+    */
+    "unbalanced": "Fallback",
+    /*
+    * code-after-break
+    * empty-block
+    * redundant-return
+    * trailing-space
+    * unreachable-code
+    * unused-function
+    * unused-label
+    * unused-local
+    * unused-vararg
+    */
+    "unused": "Fallback"
+}
+```
+
+# diagnostics.groupSeverity
+
+グループ内の診断の重大度を変更します。
+`Fallback` は、このグループ内の診断が個別に `diagnostics.severity` によって制御されることを意味します。
+その他の設定は、末尾に `!` が付いていない個別の設定を上書きします。
+
+
+## type
+
+```ts
+object<string, string>
+```
+
+## enum
+
+* ``"Error"``
+* ``"Warning"``
+* ``"Information"``
+* ``"Hint"``
+* ``"Fallback"``
+
+## default
+
+```jsonc
+{
+    /*
+    * ambiguity-1
+    * count-down-loop
+    * different-requires
+    * newfield-call
+    * newline-call
+    */
+    "ambiguity": "Fallback",
+    /*
+    * await-in-sync
+    * not-yieldable
+    */
+    "await": "Fallback",
+    /*
+    * codestyle-check
+    * name-style-check
+    * spell-check
+    */
+    "codestyle": "Fallback",
+    /*
+    * global-element
+    */
+    "conventions": "Fallback",
+    /*
+    * duplicate-index
+    * duplicate-set-field
+    */
+    "duplicate": "Fallback",
+    /*
+    * global-in-nil-env
+    * lowercase-global
+    * undefined-env-child
+    * undefined-global
+    */
+    "global": "Fallback",
+    /*
+    * circle-doc-class
+    * doc-field-no-class
+    * duplicate-doc-alias
+    * duplicate-doc-field
+    * duplicate-doc-param
+    * incomplete-signature-doc
+    * missing-global-doc
+    * missing-local-export-doc
+    * undefined-doc-class
+    * undefined-doc-name
+    * undefined-doc-param
+    * unknown-cast-variable
+    * unknown-diag-code
+    * unknown-operator
+    */
+    "luadoc": "Fallback",
+    /*
+    * redefined-local
+    */
+    "redefined": "Fallback",
+    /*
+    * close-non-object
+    * deprecated
+    * discard-returns
+    * invisible
+    */
+    "strict": "Fallback",
+    /*
+    * no-unknown
+    */
+    "strong": "Fallback",
+    /*
+    * assign-type-mismatch
+    * cast-local-type
+    * cast-type-mismatch
+    * inject-field
+    * need-check-nil
+    * param-type-mismatch
+    * return-type-mismatch
+    * undefined-field
+    */
+    "type-check": "Fallback",
+    /*
+    * missing-fields
+    * missing-parameter
+    * missing-return
+    * missing-return-value
+    * redundant-parameter
+    * redundant-return-value
+    * redundant-value
+    * unbalanced-assignments
+    */
+    "unbalanced": "Fallback",
+    /*
+    * code-after-break
+    * empty-block
+    * redundant-return
+    * trailing-space
+    * unreachable-code
+    * unused-function
+    * unused-label
+    * unused-local
+    * unused-vararg
+    */
+    "unused": "Fallback"
+}
+```
+
+# diagnostics.ignoredFiles
+
+無視されているファイルをどのように診断するか。
+
+## type
+
+```ts
+string
+```
+
+## enum
+
+* ``"Enable"``: 常にこれらのファイルを診断します。
+* ``"Opened"``: これらのファイルが開かれているときのみ診断します。
+* ``"Disable"``: これらのファイルは診断しません。
+
+## default
+
+```jsonc
+"Opened"
+```
+
+# diagnostics.libraryFiles
+
+`Lua.workspace.library` 経由で読み込まれたファイルをどのように診断するか。
+
+## type
+
+```ts
+string
+```
+
+## enum
+
+* ``"Enable"``: 常にこれらのファイルを診断します。
+* ``"Opened"``: これらのファイルが開かれているときのみ診断します。
+* ``"Disable"``: これらのファイルは診断しません。
+
+## default
+
+```jsonc
+"Opened"
+```
+
+# diagnostics.neededFileStatus
+
+* Opened: 開いているファイルのみを診断
+* Any:    すべてのファイルを診断
+* None:   この診断を無効化
+
+末尾に `!` を付けると、グループ設定 `diagnostics.groupFileStatus` を上書きします。
+
+
+## type
+
+```ts
+object<string, string>
+```
+
+## enum
+
+* ``"Any"``
+* ``"Opened"``
+* ``"None"``
+* ``"Any!"``
+* ``"Opened!"``
+* ``"None!"``
+
+## default
+
+```jsonc
+{
+    /*
+    演算子優先順位のあいまいさ診断を有効にします。例: `num or 0 + 1` には `(num or 0) + 1` を推奨します。
+    */
+    "ambiguity-1": "Any",
+    /*
+    値の型が代入先の型と一致しない代入の診断を有効にします。
+    */
+    "assign-type-mismatch": "Opened",
+    /*
+    同期関数内で非同期関数を呼び出す場合の診断を有効にします。
+    */
+    "await-in-sync": "None",
+    /*
+    ローカル変数のキャスト先の型が定義と一致しない場合の診断を有効にします。
+    */
+    "cast-local-type": "Opened",
+    /*
+    キャスト先の型が元の型と一致しない場合の診断を有効にします。
+    */
+    "cast-type-mismatch": "Opened",
+    "circle-doc-class": "Any",
+    /*
+    オブジェクト以外を閉じようとする場合の診断を有効にします。
+    */
+    "close-non-object": "Any",
+    /*
+    ループ内で`break`の後に配置されたコードの診断を有効にします。
+    */
+    "code-after-break": "Opened",
+    /*
+    スタイルに合わない行の診断を有効にします。
+    */
+    "codestyle-check": "None",
+    /*
+    減少しないため上限に到達しない `for` ループの診断を有効にします。
+    */
+    "count-down-loop": "Any",
+    /*
+    非推奨APIを強調する診断を有効にします。
+    */
+    "deprecated": "Any",
+    /*
+    異なるパスで同じファイルをrequireする場合の診断を有効にします。
+    */
+    "different-requires": "Any",
+    /*
+    `---@nodiscard` が付いた関数の戻り値を無視した呼び出しの診断を有効にします。
+    */
+    "discard-returns": "Any",
+    /*
+    クラス注釈なしでフィールド注釈がある場合の診断を有効にします。
+    */
+    "doc-field-no-class": "Any",
+    /*
+    エイリアス注釈名の重複診断を有効にします。
+    */
+    "duplicate-doc-alias": "Any",
+    /*
+    フィールド注釈名の重複診断を有効にします。
+    */
+    "duplicate-doc-field": "Any",
+    /*
+    パラメータ注釈名の重複診断を有効にします。
+    */
+    "duplicate-doc-param": "Any",
+    /*
+    重複したテーブルインデックスの診断を有効にします。
+    */
+    "duplicate-index": "Any",
+    /*
+    クラス内で同じフィールドを複数回設定する診断を有効にします。
+    */
+    "duplicate-set-field": "Opened",
+    /*
+    空のコードブロック診断を有効にします。
+    */
+    "empty-block": "Opened",
+    /*
+    グローバル要素に関する警告診断を有効にします。
+    */
+    "global-element": "None",
+    /*
+    グローバル変数を使用できない（`_ENV` が `nil`）場合の診断を有効にします。
+    */
+    "global-in-nil-env": "Any",
+    /*
+    関数の @param または @return 注釈が不完全な場合の診断。
+    */
+    "incomplete-signature-doc": "None",
+    "inject-field": "Opened",
+    /*
+    不可視フィールドへのアクセス診断を有効にします。
+    */
+    "invisible": "Any",
+    /*
+    先頭小文字のグローバル変数定義の診断を有効にします。
+    */
+    "lowercase-global": "Any",
+    "missing-fields": "Any",
+    /*
+    グローバル関数の注釈不足の診断。コメントと全パラメータ・戻り値の注釈が必要です。
+    */
+    "missing-global-doc": "None",
+    /*
+    エクスポートされたローカル関数の注釈不足の診断。
+    */
+    "missing-local-export-doc": "None",
+    /*
+    注釈パラメータ数より少ない引数で関数を呼び出した場合の診断を有効にします。
+    */
+    "missing-parameter": "Any",
+    /*
+    戻り注釈があるのにreturn文がない場合の診断を有効にします。
+    */
+    "missing-return": "Any",
+    /*
+    戻り値を宣言しているのに値を返さないreturn文の診断を有効にします。
+    */
+    "missing-return-value": "Any",
+    /*
+    名前スタイルの診断を有効にします。
+    */
+    "name-style-check": "None",
+    /*
+    以前に`nil`または任意型が代入された変数を使用する際のnilチェック診断を有効にします。
+    */
+    "need-check-nil": "Opened",
+    /*
+    newfield 呼び出しの診断を有効にします。テーブル定義中に関数呼び出しの括弧が次の行に現れる場合に発生します。
+    */
+    "newfield-call": "Any",
+    /*
+    改行呼び出しの診断を有効にします。`(` で始まる行が前の行への関数呼び出しとして構文解析される場合に発生します。
+    */
+    "newline-call": "Any",
+    /*
+    型を推論できない場合の診断を有効にします。
+    */
+    "no-unknown": "None",
+    /*
+    許可されない場所での`coroutine.yield()`呼び出しの診断を有効にします。
+    */
+    "not-yieldable": "None",
+    /*
+    注釈の型と一致しない引数を渡した場合の診断を有効にします。
+    */
+    "param-type-mismatch": "Opened",
+    /*
+    ローカル変数の再定義診断を有効にします。
+    */
+    "redefined-local": "Opened",
+    /*
+    冗長な関数パラメータの診断を有効にします。
+    */
+    "redundant-parameter": "Any",
+    /*
+    不要なreturn文の診断を有効にします。
+    */
+    "redundant-return": "Opened",
+    /*
+    注釈にない追加の戻り値を返すreturn文の診断を有効にします。
+    */
+    "redundant-return-value": "Any",
+    /*
+    代入時の余分な値の診断を有効にします。値の数が変数の数を超える場合に発生します。
+    */
+    "redundant-value": "Any",
+    /*
+    戻り値の型が注釈と一致しない場合の診断を有効にします。
+    */
+    "return-type-mismatch": "Opened",
+    /*
+    文字列内のタイポ診断を有効にします。
+    */
+    "spell-check": "None",
+    /*
+    行末の余分な空白の診断を有効にします。
+    */
+    "trailing-space": "Opened",
+    /*
+    多重代入で一部の変数が値を得られない場合の診断を有効にします（例: `local x,y = 1`）。
+    */
+    "unbalanced-assignments": "Any",
+    /*
+    未定義クラスを参照するクラス注釈の診断を有効にします。
+    */
+    "undefined-doc-class": "Any",
+    /*
+    未定義の型またはエイリアスを参照する注釈の診断を有効にします。
+    */
+    "undefined-doc-name": "Any",
+    /*
+    関数定義に存在しないパラメータへの注釈の診断を有効にします。
+    */
+    "undefined-doc-param": "Any",
+    /*
+    未定義環境変数の診断を有効にします。`_ENV` を新しいリテラルテーブルに設定した結果、使用中のグローバルが存在しない場合に発生します。
+    */
+    "undefined-env-child": "Any",
+    /*
+    未定義フィールドを参照する場合の診断を有効にします。
+    */
+    "undefined-field": "Opened",
+    /*
+    未定義のグローバル変数の診断を有効にします。
+    */
+    "undefined-global": "Any",
+    /*
+    未定義変数へのキャスト診断を有効にします。
+    */
+    "unknown-cast-variable": "Any",
+    /*
+    不明な診断コードが入力された場合の診断を有効にします。
+    */
+    "unknown-diag-code": "Any",
+    /*
+    不明な演算子の診断を有効にします。
+    */
+    "unknown-operator": "Any",
+    /*
+    到達不能コードの診断を有効にします。
+    */
+    "unreachable-code": "Opened",
+    /*
+    未使用の関数の診断を有効にします。
+    */
+    "unused-function": "Opened",
+    /*
+    未使用ラベルの診断を有効にします。
+    */
+    "unused-label": "Opened",
+    /*
+    未使用のローカル変数の診断を有効にします。
+    */
+    "unused-local": "Opened",
+    /*
+    未使用の可変引数の診断を有効にします。
+    */
+    "unused-vararg": "Opened"
+}
+```
+
+# diagnostics.severity
+
+診断の重大度を変更します。
+
+末尾に `!` を付けると、グループ設定 `diagnostics.groupSeverity` を上書きします。
+
+
+## type
+
+```ts
+object<string, string>
+```
+
+## enum
+
+* ``"Error"``
+* ``"Warning"``
+* ``"Information"``
+* ``"Hint"``
+* ``"Error!"``
+* ``"Warning!"``
+* ``"Information!"``
+* ``"Hint!"``
+
+## default
+
+```jsonc
+{
+    /*
+    演算子優先順位のあいまいさ診断を有効にします。例: `num or 0 + 1` には `(num or 0) + 1` を推奨します。
+    */
+    "ambiguity-1": "Warning",
+    /*
+    値の型が代入先の型と一致しない代入の診断を有効にします。
+    */
+    "assign-type-mismatch": "Warning",
+    /*
+    同期関数内で非同期関数を呼び出す場合の診断を有効にします。
+    */
+    "await-in-sync": "Warning",
+    /*
+    ローカル変数のキャスト先の型が定義と一致しない場合の診断を有効にします。
+    */
+    "cast-local-type": "Warning",
+    /*
+    キャスト先の型が元の型と一致しない場合の診断を有効にします。
+    */
+    "cast-type-mismatch": "Warning",
+    "circle-doc-class": "Warning",
+    /*
+    オブジェクト以外を閉じようとする場合の診断を有効にします。
+    */
+    "close-non-object": "Warning",
+    /*
+    ループ内で`break`の後に配置されたコードの診断を有効にします。
+    */
+    "code-after-break": "Hint",
+    /*
+    スタイルに合わない行の診断を有効にします。
+    */
+    "codestyle-check": "Warning",
+    /*
+    減少しないため上限に到達しない `for` ループの診断を有効にします。
+    */
+    "count-down-loop": "Warning",
+    /*
+    非推奨APIを強調する診断を有効にします。
+    */
+    "deprecated": "Warning",
+    /*
+    異なるパスで同じファイルをrequireする場合の診断を有効にします。
+    */
+    "different-requires": "Warning",
+    /*
+    `---@nodiscard` が付いた関数の戻り値を無視した呼び出しの診断を有効にします。
+    */
+    "discard-returns": "Warning",
+    /*
+    クラス注釈なしでフィールド注釈がある場合の診断を有効にします。
+    */
+    "doc-field-no-class": "Warning",
+    /*
+    エイリアス注釈名の重複診断を有効にします。
+    */
+    "duplicate-doc-alias": "Warning",
+    /*
+    フィールド注釈名の重複診断を有効にします。
+    */
+    "duplicate-doc-field": "Warning",
+    /*
+    パラメータ注釈名の重複診断を有効にします。
+    */
+    "duplicate-doc-param": "Warning",
+    /*
+    重複したテーブルインデックスの診断を有効にします。
+    */
+    "duplicate-index": "Warning",
+    /*
+    クラス内で同じフィールドを複数回設定する診断を有効にします。
+    */
+    "duplicate-set-field": "Warning",
+    /*
+    空のコードブロック診断を有効にします。
+    */
+    "empty-block": "Hint",
+    /*
+    グローバル要素に関する警告診断を有効にします。
+    */
+    "global-element": "Warning",
+    /*
+    グローバル変数を使用できない（`_ENV` が `nil`）場合の診断を有効にします。
+    */
+    "global-in-nil-env": "Warning",
+    /*
+    関数の @param または @return 注釈が不完全な場合の診断。
+    */
+    "incomplete-signature-doc": "Warning",
+    "inject-field": "Warning",
+    /*
+    不可視フィールドへのアクセス診断を有効にします。
+    */
+    "invisible": "Warning",
+    /*
+    先頭小文字のグローバル変数定義の診断を有効にします。
+    */
+    "lowercase-global": "Information",
+    "missing-fields": "Warning",
+    /*
+    グローバル関数の注釈不足の診断。コメントと全パラメータ・戻り値の注釈が必要です。
+    */
+    "missing-global-doc": "Warning",
+    /*
+    エクスポートされたローカル関数の注釈不足の診断。
+    */
+    "missing-local-export-doc": "Warning",
+    /*
+    注釈パラメータ数より少ない引数で関数を呼び出した場合の診断を有効にします。
+    */
+    "missing-parameter": "Warning",
+    /*
+    戻り注釈があるのにreturn文がない場合の診断を有効にします。
+    */
+    "missing-return": "Warning",
+    /*
+    戻り値を宣言しているのに値を返さないreturn文の診断を有効にします。
+    */
+    "missing-return-value": "Warning",
+    /*
+    名前スタイルの診断を有効にします。
+    */
+    "name-style-check": "Warning",
+    /*
+    以前に`nil`または任意型が代入された変数を使用する際のnilチェック診断を有効にします。
+    */
+    "need-check-nil": "Warning",
+    /*
+    newfield 呼び出しの診断を有効にします。テーブル定義中に関数呼び出しの括弧が次の行に現れる場合に発生します。
+    */
+    "newfield-call": "Warning",
+    /*
+    改行呼び出しの診断を有効にします。`(` で始まる行が前の行への関数呼び出しとして構文解析される場合に発生します。
+    */
+    "newline-call": "Warning",
+    /*
+    型を推論できない場合の診断を有効にします。
+    */
+    "no-unknown": "Warning",
+    /*
+    許可されない場所での`coroutine.yield()`呼び出しの診断を有効にします。
+    */
+    "not-yieldable": "Warning",
+    /*
+    注釈の型と一致しない引数を渡した場合の診断を有効にします。
+    */
+    "param-type-mismatch": "Warning",
+    /*
+    ローカル変数の再定義診断を有効にします。
+    */
+    "redefined-local": "Hint",
+    /*
+    冗長な関数パラメータの診断を有効にします。
+    */
+    "redundant-parameter": "Warning",
+    /*
+    不要なreturn文の診断を有効にします。
+    */
+    "redundant-return": "Hint",
+    /*
+    注釈にない追加の戻り値を返すreturn文の診断を有効にします。
+    */
+    "redundant-return-value": "Warning",
+    /*
+    代入時の余分な値の診断を有効にします。値の数が変数の数を超える場合に発生します。
+    */
+    "redundant-value": "Warning",
+    /*
+    戻り値の型が注釈と一致しない場合の診断を有効にします。
+    */
+    "return-type-mismatch": "Warning",
+    /*
+    文字列内のタイポ診断を有効にします。
+    */
+    "spell-check": "Information",
+    /*
+    行末の余分な空白の診断を有効にします。
+    */
+    "trailing-space": "Hint",
+    /*
+    多重代入で一部の変数が値を得られない場合の診断を有効にします（例: `local x,y = 1`）。
+    */
+    "unbalanced-assignments": "Warning",
+    /*
+    未定義クラスを参照するクラス注釈の診断を有効にします。
+    */
+    "undefined-doc-class": "Warning",
+    /*
+    未定義の型またはエイリアスを参照する注釈の診断を有効にします。
+    */
+    "undefined-doc-name": "Warning",
+    /*
+    関数定義に存在しないパラメータへの注釈の診断を有効にします。
+    */
+    "undefined-doc-param": "Warning",
+    /*
+    未定義環境変数の診断を有効にします。`_ENV` を新しいリテラルテーブルに設定した結果、使用中のグローバルが存在しない場合に発生します。
+    */
+    "undefined-env-child": "Information",
+    /*
+    未定義フィールドを参照する場合の診断を有効にします。
+    */
+    "undefined-field": "Warning",
+    /*
+    未定義のグローバル変数の診断を有効にします。
+    */
+    "undefined-global": "Warning",
+    /*
+    未定義変数へのキャスト診断を有効にします。
+    */
+    "unknown-cast-variable": "Warning",
+    /*
+    不明な診断コードが入力された場合の診断を有効にします。
+    */
+    "unknown-diag-code": "Warning",
+    /*
+    不明な演算子の診断を有効にします。
+    */
+    "unknown-operator": "Warning",
+    /*
+    到達不能コードの診断を有効にします。
+    */
+    "unreachable-code": "Hint",
+    /*
+    未使用の関数の診断を有効にします。
+    */
+    "unused-function": "Hint",
+    /*
+    未使用ラベルの診断を有効にします。
+    */
+    "unused-label": "Hint",
+    /*
+    未使用のローカル変数の診断を有効にします。
+    */
+    "unused-local": "Hint",
+    /*
+    未使用の可変引数の診断を有効にします。
+    */
+    "unused-vararg": "Hint"
+}
+```
+
+# diagnostics.unusedLocalExclude
+
+変数名が次のパターンに一致する場合、`unused-local` を診断しません。
+
+## type
+
+```ts
+Array<string>
+```
+
+## default
+
+```jsonc
+[]
+```
+
+# diagnostics.workspaceDelay
+
+ワークスペース診断の待ち時間（ミリ秒）。
+
+## type
+
+```ts
+integer
+```
+
+## default
+
+```jsonc
+3000
+```
+
+# diagnostics.workspaceEvent
+
+ワークスペース診断をトリガーするタイミングを設定します。
+
+## type
+
+```ts
+string
+```
+
+## enum
+
+* ``"OnChange"``: ファイルが変更されたときにワークスペース診断をトリガーします。
+* ``"OnSave"``: ファイルが保存されたときにワークスペース診断をトリガーします。
+* ``"None"``: ワークスペース診断を無効にします。
+
+## default
+
+```jsonc
+"OnSave"
+```
+
+# diagnostics.workspaceRate
+
+ワークスペース診断の実行レート（％）。この値を下げると CPU 使用率は低下しますが、ワークスペース診断の速度も低下します。現在編集中のファイルの診断は常に全速で行われ、この設定の影響を受けません。
+
+## type
+
+```ts
+integer
+```
+
+## default
+
+```jsonc
+100
+```
+
+# doc.packageName
+
+特定のフィールド名をパッケージとして扱います。例: `m_*` は `XXX.m_id` や `XXX.m_type` がパッケージであり、定義されているファイル内でのみアクセス可能です。
+
+## type
+
+```ts
+Array<string>
+```
+
+## default
+
+```jsonc
+[]
+```
+
+# doc.privateName
+
+特定のフィールド名をプライベートとして扱います。例: `m_*` は `XXX.m_id` や `XXX.m_type` がプライベートであり、定義されているクラス内でのみアクセス可能です。
+
+## type
+
+```ts
+Array<string>
+```
+
+## default
+
+```jsonc
+[]
+```
+
+# doc.protectedName
+
+特定のフィールド名をプロテクトとして扱います。例: `m_*` は `XXX.m_id` や `XXX.m_type` がプロテクトであり、定義クラスおよびそのサブクラスでのみアクセス可能です。
+
+## type
+
+```ts
+Array<string>
+```
+
+## default
+
+```jsonc
+[]
+```
+
+# doc.regengine
+
+ドキュメントスコープ名のマッチに使用する正規表現エンジン。
+
+## type
+
+```ts
+string
+```
+
+## enum
+
+* ``"glob"``: デフォルトの軽量パターン構文。
+* ``"lua"``: Luaスタイルの正規表現（フル機能）。
+
+## default
+
+```jsonc
+"glob"
+```
+
+# docScriptPath
+
+ドキュメントスコープ名のマッチに使用する正規表現エンジン。
+
+## type
+
+```ts
+string
+```
+
+## default
+
+```jsonc
+""
+```
+
+# format.defaultConfig
+
+デフォルトのフォーマット設定。ワークスペース内の`.editorconfig`ファイルより優先度が低くなります。
+[formatter docs](https://github.com/CppCXY/EmmyLuaCodeStyle/tree/master/docs) を参照してください。
+
+
+## type
+
+```ts
+Object<string, string>
+```
+
+## default
+
+```jsonc
+{}
+```
+
+# format.enable
+
+コードフォーマッタを有効にします。
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+true
+```
+
+# hint.arrayIndex
+
+テーブル構築時に配列インデックスのヒントを表示します。
+
+## type
+
+```ts
+string
+```
+
+## enum
+
+* ``"Enable"``: すべてのテーブルでヒントを表示します。
+* ``"Auto"``: テーブルが3要素を超える、または混在テーブルの場合のみヒントを表示します。
+* ``"Disable"``: 配列インデックスのヒントを無効にします。
+
+## default
+
+```jsonc
+"Auto"
+```
+
+# hint.await
+
+呼び出す関数に `---@async` が付いている場合、呼び出し箇所で `await` を提案します。
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+true
+```
+
+# hint.awaitPropagate
+
+`await` の伝播を有効にします。`---@async` が付いた関数を呼び出す関数は、自動的に `---@async` とマークされます。
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+false
+```
+
+# hint.enable
+
+インレイヒントを有効にします。
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+false
+```
+
+# hint.paramName
+
+関数呼び出し時にパラメータ名のヒントを表示します。
+
+## type
+
+```ts
+string
+```
+
+## enum
+
+* ``"All"``: すべての型のパラメータを表示します。
+* ``"Literal"``: リテラル型のパラメータのみを表示します。
+* ``"Disable"``: パラメータヒントを無効にします。
+
+## default
+
+```jsonc
+"All"
+```
+
+# hint.paramType
+
+関数のパラメータに型ヒントを表示します。
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+true
+```
+
+# hint.semicolon
+
+文末にセミコロンがない場合に仮想セミコロンを表示します。
+
+## type
+
+```ts
+string
+```
+
+## enum
+
+* ``"All"``: すべての文で仮想セミコロンを表示します。
+* ``"SameLine"``: 同じ行に2つの文がある場合、その間にセミコロンを表示します。
+* ``"Disable"``: 仮想セミコロンを無効にします。
+
+## default
+
+```jsonc
+"SameLine"
+```
+
+# hint.setType
+
+代入操作で型ヒントを表示します。
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+false
+```
+
+# hover.enable
+
+ホバーを有効にします。
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+true
+```
+
+# hover.enumsLimit
+
+値が複数の型に対応する場合、表示される型の数を制限します。
+
+## type
+
+```ts
+integer
+```
+
+## default
+
+```jsonc
+5
+```
+
+# hover.expandAlias
+
+エイリアスを展開するかどうか。たとえば、`---@alias myType boolean|number`を展開すると`boolean|number`として表示され、そうでない場合は`myType`として表示されます。
+
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+true
+```
+
+# hover.previewFields
+
+テーブルをホバーで表示する際、フィールドのプレビューの最大数を制限します。
+
+## type
+
+```ts
+integer
+```
+
+## default
+
+```jsonc
+10
+```
+
+# hover.viewNumber
+
+ホバーで数値内容を表示します（リテラルが10進数でない場合のみ）。
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+true
+```
+
+# hover.viewString
+
+ホバーで文字列の内容を表示します（リテラルにエスケープ文字が含まれている場合のみ）。
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+true
+```
+
+# hover.viewStringMax
+
+ホバーで表示する文字列内容の最大長。
+
+## type
+
+```ts
+integer
+```
+
+## default
+
+```jsonc
+1000
+```
+
+# language.completeAnnotation
+
+(VSCodeのみ) 注釈行の改行後に自動で "---@ " を挿入します。
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+true
+```
+
+# language.fixIndent
+
+(VSCodeのみ) 誤った自動インデントを修正します。例えば、"function" を含む文字列内で改行したときの不正なインデントなど。
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+true
+```
+
+# misc.executablePath
+
+VSCodeでの実行可能ファイルのパスを指定します。
+
+## type
+
+```ts
+string
+```
+
+## default
+
+```jsonc
+""
+```
+
+# misc.parameters
+
+VSCode で言語サーバーを起動するときの[コマンドライン引数](https://github.com/LuaLS/lua-telemetry-server/tree/master/method)。
+
+## type
+
+```ts
+Array<string>
+```
+
+## default
+
+```jsonc
+[]
+```
+
+# nameStyle.config
+
+命名スタイル設定。
+[formatter docs](https://github.com/CppCXY/EmmyLuaCodeStyle/tree/master/docs) を参照してください。
+
+
+## type
+
+```ts
+Object<string, string | array>
+```
+
+## default
+
+```jsonc
+{}
+```
+
+# runtime.builtin
+
+組み込みライブラリの有効状態を調整します。実際のランタイム環境に応じて、存在しないライブラリを無効化（または再定義）できます。
+
+* `default`: ランタイムバージョンに応じてライブラリを有効／無効にします
+* `enable`: 常に有効
+* `disable`: 常に無効
+
+
+## type
+
+```ts
+object<string, string>
+```
+
+## enum
+
+* ``"default"``
+* ``"enable"``
+* ``"disable"``
+
+## default
+
+```jsonc
+{
+    "basic": "default",
+    "bit": "default",
+    "bit32": "default",
+    "builtin": "default",
+    "coroutine": "default",
+    "debug": "default",
+    "ffi": "default",
+    "io": "default",
+    "jit": "default",
+    "jit.profile": "default",
+    "jit.util": "default",
+    "math": "default",
+    "os": "default",
+    "package": "default",
+    "string": "default",
+    "string.buffer": "default",
+    "table": "default",
+    "table.clear": "default",
+    "table.new": "default",
+    "utf8": "default"
+}
+```
+
+# runtime.fileEncoding
+
+ファイルのエンコーディング。`ansi` オプションは `Windows` プラットフォームでのみ利用可能です。
+
+## type
+
+```ts
+string
+```
+
+## enum
+
+* ``"utf8"``
+* ``"ansi"``
+* ``"utf16le"``
+* ``"utf16be"``
+
+## default
+
+```jsonc
+"utf8"
+```
+
+# runtime.meta
+
+メタファイルのディレクトリ名の形式。
+
+## type
+
+```ts
+string
+```
+
+## default
+
+```jsonc
+"${version} ${language} ${encoding}"
+```
+
+# runtime.nonstandardSymbol
+
+非標準の記号をサポートします。ランタイム環境がこれらの記号をサポートしていることを確認してください。
+
+## type
+
+```ts
+Array<string>
+```
+
+## enum
+
+* ``"//"``
+* ``"/**/"``
+* ``"`"``
+* ``"+="``
+* ``"-="``
+* ``"*="``
+* ``"/="``
+* ``"%="``
+* ``"^="``
+* ``"//="``
+* ``"|="``
+* ``"&="``
+* ``"<<="``
+* ``">>="``
+* ``"||"``
+* ``"&&"``
+* ``"!"``
+* ``"!="``
+* ``"continue"``
+* ``"|lambda|"``
+
+## default
+
+```jsonc
+[]
+```
+
+# runtime.path
+
+`require` を使用する際、入力名に基づいてファイルを探す方法。
+この設定を `?/init.lua` にすると、`require 'myfile'` と入力したとき、読み込まれたファイルから `${workspace}/myfile/init.lua` が検索されます。
+`runtime.pathStrict` が `false` の場合、`${workspace}/**/myfile/init.lua` も検索対象になります。
+ワークスペース外のファイルを読み込みたい場合は、先に `Lua.workspace.library` を設定する必要があります。
+
+
+## type
+
+```ts
+Array<string>
+```
+
+## default
+
+```jsonc
+["?.lua","?/init.lua"]
+```
+
+# runtime.pathStrict
+
+有効にすると、`runtime.path` は最上位のディレクトリ階層のみを検索します。詳細は `runtime.path` の説明を参照してください。
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+false
+```
+
+# runtime.plugin
+
+プラグインのパス。詳細は [wiki](https://luals.github.io/wiki/plugins) を参照してください。
+
+## type
+
+```ts
+string | array
+```
+
+## default
+
+```jsonc
+null
+```
+
+# runtime.pluginArgs
+
+プラグインに渡す追加引数。
+
+## type
+
+```ts
+array | object
+```
+
+## default
+
+```jsonc
+null
+```
+
+# runtime.special
+
+カスタムのグローバル変数を一部の特別な組み込み変数として扱い、言語サーバーが特別なサポートを提供します。
+以下の例では、`include` を `require` として扱います。
+```json
+"Lua.runtime.special" : {
+    "include" : "require"
+}
+```
+
+
+## type
+
+```ts
+Object<string, string>
+```
+
+## default
+
+```jsonc
+{}
+```
+
+# runtime.unicodeName
+
+名前に Unicode 文字を使用できるようにします。
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+false
+```
+
+# runtime.version
+
+Lua のランタイムバージョン。
+
+## type
+
+```ts
+string
+```
+
+## enum
+
+* ``"Lua 5.1"``
+* ``"Lua 5.2"``
+* ``"Lua 5.3"``
+* ``"Lua 5.4"``
+* ``"Lua 5.5"``
+* ``"LuaJIT"``
+
+## default
+
+```jsonc
+"Lua 5.4"
+```
+
+# semantic.annotation
+
+型注釈のセマンティックカラーリング。
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+true
+```
+
+# semantic.enable
+
+セマンティックカラーを有効にします。効果を発揮するために`editor.semanticHighlighting.enabled`を`true`に設定する必要があるかもしれません。
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+true
+```
+
+# semantic.keyword
+
+キーワード/リテラル/演算子のセマンティックカラーリング。エディタが構文カラーリングをできない場合のみ、この機能を有効にする必要があります。
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+false
+```
+
+# semantic.variable
+
+変数/フィールド/パラメータのセマンティックカラーリング。
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+true
+```
+
+# signatureHelp.enable
+
+シグネチャヘルプを有効にします。
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+true
+```
+
+# spell.dict
+
+スペルチェック用のカスタム単語。
+
+## type
+
+```ts
+Array<string>
+```
+
+## default
+
+```jsonc
+[]
+```
+
+# type.castNumberToInteger
+
+`number` 型を `integer` 型に代入することを許可します。
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+true
+```
+
+# type.checkTableShape
+
+テーブルの形状を厳密にチェックします。
+
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+false
+```
+
+# type.inferParamType
+
+パラメータ型が注釈されていない場合、関数の呼び出し箇所から推論します。
+
+この設定が`false`の場合、注釈がないパラメータの型は`any`になります。
+
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+false
+```
+
+# type.inferTableSize
+
+型推論時に解析するテーブルフィールドの最大数。
+
+## type
+
+```ts
+integer
+```
+
+## default
+
+```jsonc
+10
+```
+
+# type.maxUnionVariants
+
+**Missing description!!**
+
+## type
+
+```ts
+integer
+```
+
+## default
+
+```jsonc
+0
+```
+
+# type.weakNilCheck
+
+共用体型のチェック時に、その中の`nil`を無視します。
+
+この設定が`false`の場合、`number|nil`型は`number`型に代入できません。`true`の場合は可能です。
+
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+false
+```
+
+# type.weakUnionCheck
+
+共用体型のどれか1つのサブタイプが条件を満たせば、共用体全体も条件を満たします。
+
+この設定が`false`の場合、`number|boolean`型は`number`型に代入できません。`true`の場合は可能です。
+
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+false
+```
+
+# typeFormat.config
+
+Luaコード入力中のフォーマット動作を設定します。
+
+## type
+
+```ts
+object<string, string>
+```
+
+## default
+
+```jsonc
+{
+    /*
+    適切な位置で`end`を自動補完するかを制御します。
+    */
+    "auto_complete_end": "true",
+    /*
+    テーブル宣言末尾にセパレータを自動付与するかを制御します。
+    */
+    "auto_complete_table_sep": "true",
+    /*
+    行を自動整形するかどうかを制御します。
+    */
+    "format_line": "true"
+}
+```
+
+# window.progressBar
+
+ステータスバーに進行状況バーを表示します。
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+true
+```
+
+# window.statusBar
+
+ステータスバーに拡張機能のステータスを表示します。
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+true
+```
+
+# workspace.checkThirdParty
+
+サードパーティライブラリの自動検出と適応。現在サポートされているライブラリ：
+
+* OpenResty
+* Cocos4.0
+* LÖVE
+* LÖVR
+* skynet
+* Jass
+
+
+## type
+
+```ts
+string | boolean
+```
+
+## default
+
+```jsonc
+null
+```
+
+# workspace.dofileRoots
+
+In addition to the current workspace, which directories `dofile` will treat as a possible root. The files in these directories will be loaded immediately.
+
+## type
+
+```ts
+Array<string>
+```
+
+## default
+
+```jsonc
+[]
+```
+
+# workspace.ignoreDir
+
+無視するファイルとディレクトリ（`.gitignore` の構文を使用）。
+
+## type
+
+```ts
+Array<string>
+```
+
+## default
+
+```jsonc
+[".vscode"]
+```
+
+# workspace.ignoreSubmodules
+
+サブモジュールを無視します。
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+true
+```
+
+# workspace.library
+
+現在のワークスペースに加えて、どのディレクトリからファイルをロードするか。これらのディレクトリ内のファイルは外部提供のコードライブラリとして扱われ、一部の機能（フィールド名の変更など）はこれらのファイルを変更しません。
+
+## type
+
+```ts
+Array<string>
+```
+
+## default
+
+```jsonc
+[]
+```
+
+# workspace.maxPreload
+
+プリロードする最大ファイル数。
+
+## type
+
+```ts
+integer
+```
+
+## default
+
+```jsonc
+5000
+```
+
+# workspace.preloadFileSize
+
+プリロード時にこの値（KB）より大きいファイルをスキップします。
+
+## type
+
+```ts
+integer
+```
+
+## default
+
+```jsonc
+500
+```
+
+# workspace.useGitIgnore
+
+`.gitignore` に記載されたファイルを無視します。
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+true
+```
+
+# workspace.userThirdParty
+
+プライベートサードパーティライブラリの設定ファイルパスをここに追加してください。組み込みの[設定ファイルパス](https://github.com/LuaLS/lua-language-server/tree/master/meta/3rd)を参照してください。
+
+## type
+
+```ts
+Array<string>
+```
+
+## default
+
+```jsonc
+[]
+```

--- a/doc/pt-br/config.md
+++ b/doc/pt-br/config.md
@@ -1,6 +1,6 @@
 # addonManager.enable
 
-Whether the addon manager is enabled or not.
+Habilita ou desabilita o gerenciador de add-ons.
 
 ## type
 
@@ -14,9 +14,9 @@ boolean
 true
 ```
 
-# addonRepositoryPath
+# addonManager.repositoryBranch
 
-Specifies the addon repository path (not related to the addon manager).
+Define o branch Git usado pelo gerenciador de add-ons.
 
 ## type
 
@@ -24,9 +24,47 @@ Specifies the addon repository path (not related to the addon manager).
 string
 ```
 
+## default
+
+```jsonc
+""
+```
+
+# addonManager.repositoryPath
+
+Define o caminho Git usado pelo gerenciador de add-ons.
+
+## type
+
+```ts
+string
+```
+
+## default
+
+```jsonc
+""
+```
+
+# addonRepositoryPath
+
+Define o caminho do repositório de add-ons (não relacionado ao gerenciador de add-ons).
+
+## type
+
+```ts
+string
+```
+
+## default
+
+```jsonc
+""
+```
+
 # codeLens.enable
 
-Enable code lens.
+Habilitar code lens.
 
 ## type
 
@@ -42,7 +80,7 @@ false
 
 # completion.autoRequire
 
-When the input looks like a file name, automatically `require` this file.
+Quando a entrada se parece com um nome de arquivo, fazer `require` desse arquivo automaticamente.
 
 ## type
 
@@ -58,7 +96,7 @@ true
 
 # completion.callSnippet
 
-Shows function call snippets.
+Mostra snippets de chamada de função.
 
 ## type
 
@@ -68,9 +106,9 @@ string
 
 ## enum
 
-* ``"Disable"``: Only shows `function name`.
-* ``"Both"``: Shows `function name` and `call snippet`.
-* ``"Replace"``: Only shows `call snippet.`
+* ``"Disable"``: Mostra apenas o `nome da função`.
+* ``"Both"``: Mostra o `nome da função` e o `trecho de chamada`.
+* ``"Replace"``: Mostra apenas o `trecho de chamada`.
 
 ## default
 
@@ -80,7 +118,7 @@ string
 
 # completion.displayContext
 
-Previewing the relevant code snippet of the suggestion may help you understand the usage of the suggestion. The number set indicates the number of intercepted lines in the code fragment. If it is set to `0`, this feature can be disabled.
+Pré-visualizar o trecho de código relevante da sugestão pode ajudar a entender seu uso. O número define quantas linhas são interceptadas no fragmento; definir como `0` desabilita este recurso.
 
 ## type
 
@@ -96,7 +134,7 @@ integer
 
 # completion.enable
 
-Enable completion.
+Habilita autocompletar.
 
 ## type
 
@@ -112,7 +150,7 @@ true
 
 # completion.keywordSnippet
 
-Shows keyword syntax snippets.
+Mostra snippets de sintaxe de palavras-chave.
 
 ## type
 
@@ -122,9 +160,9 @@ string
 
 ## enum
 
-* ``"Disable"``: Only shows `keyword`.
-* ``"Both"``: Shows `keyword` and `syntax snippet`.
-* ``"Replace"``: Only shows `syntax snippet`.
+* ``"Disable"``: Mostra apenas a `palavra-chave`.
+* ``"Both"``: Mostra a `palavra-chave` e o `trecho de sintaxe`.
+* ``"Replace"``: Mostra apenas o `trecho de sintaxe`.
 
 ## default
 
@@ -132,9 +170,25 @@ string
 "Replace"
 ```
 
+# completion.maxSuggestCount
+
+Número máximo de campos analisados para autocompletar. Se um objeto tiver mais campos que esse limite, serão necessárias entradas mais específicas para que as sugestões apareçam.
+
+## type
+
+```ts
+integer
+```
+
+## default
+
+```jsonc
+100
+```
+
 # completion.postfix
 
-The symbol used to trigger the postfix suggestion.
+Símbolo usado para acionar sugestões de pós-fixo.
 
 ## type
 
@@ -150,7 +204,7 @@ string
 
 # completion.requireSeparator
 
-The separator used when `require`.
+Separador usado em `require`.
 
 ## type
 
@@ -166,7 +220,7 @@ string
 
 # completion.showParams
 
-Display parameters in completion list. When the function has multiple definitions, they will be displayed separately.
+Mostrar parâmetros na lista de conclusão. Se a função tiver várias definições, elas serão exibidas separadamente.
 
 ## type
 
@@ -182,7 +236,7 @@ true
 
 # completion.showWord
 
-Show contextual words in suggestions.
+Mostrar palavras de contexto nas sugestões.
 
 ## type
 
@@ -192,9 +246,9 @@ string
 
 ## enum
 
-* ``"Enable"``: Always show context words in suggestions.
-* ``"Fallback"``: Contextual words are only displayed when suggestions based on semantics cannot be provided.
-* ``"Disable"``: Do not display context words.
+* ``"Enable"``: Sempre mostrar palavras de contexto nas sugestões.
+* ``"Fallback"``: Mostrar palavras de contexto somente quando não houver sugestões baseadas em semântica.
+* ``"Disable"``: Não mostrar palavras de contexto.
 
 ## default
 
@@ -204,7 +258,7 @@ string
 
 # completion.workspaceWord
 
-Whether the displayed context word contains the content of other files in the workspace.
+Define se as palavras de contexto exibidas incluem conteúdo de outros arquivos da workspace.
 
 ## type
 
@@ -220,7 +274,7 @@ true
 
 # diagnostics.disable
 
-Disabled diagnostic (Use code in hover brackets).
+Diagnósticos desabilitados (use o código nos colchetes do hover).
 
 ## type
 
@@ -234,6 +288,7 @@ Array<string>
 * ``"ambiguity-1"``
 * ``"ambiguous-syntax"``
 * ``"args-after-dots"``
+* ``"assign-const-global"``
 * ``"assign-type-mismatch"``
 * ``"await-in-sync"``
 * ``"block-after-else"``
@@ -255,6 +310,7 @@ Array<string>
 * ``"duplicate-index"``
 * ``"duplicate-set-field"``
 * ``"empty-block"``
+* ``"env-is-global"``
 * ``"err-assign-as-eq"``
 * ``"err-c-long-comment"``
 * ``"err-comment-prefix"``
@@ -264,6 +320,7 @@ Array<string>
 * ``"err-nonstandard-symbol"``
 * ``"err-then-as-do"``
 * ``"exp-in-action"``
+* ``"global-close-attribute"``
 * ``"global-element"``
 * ``"global-in-nil-env"``
 * ``"incomplete-signature-doc"``
@@ -318,6 +375,7 @@ Array<string>
 * ``"missing-parameter"``
 * ``"missing-return"``
 * ``"missing-return-value"``
+* ``"multi-close"``
 * ``"name-style-check"``
 * ``"need-check-nil"``
 * ``"need-paren"``
@@ -347,6 +405,7 @@ Array<string>
 * ``"undefined-global"``
 * ``"unexpect-dots"``
 * ``"unexpect-efunc-name"``
+* ``"unexpect-gfunc-name"``
 * ``"unexpect-lfunc-name"``
 * ``"unexpect-symbol"``
 * ``"unicode-name"``
@@ -356,11 +415,13 @@ Array<string>
 * ``"unknown-operator"``
 * ``"unknown-symbol"``
 * ``"unreachable-code"``
+* ``"unsupport-named-vararg"``
 * ``"unsupport-symbol"``
 * ``"unused-function"``
 * ``"unused-label"``
 * ``"unused-local"``
 * ``"unused-vararg"``
+* ``"variable-not-declared"``
 
 ## default
 
@@ -368,25 +429,9 @@ Array<string>
 []
 ```
 
-# diagnostics.disableScheme
-
-Do not diagnose Lua files that use the following scheme.
-
-## type
-
-```ts
-Array<string>
-```
-
-## default
-
-```jsonc
-["git"]
-```
-
 # diagnostics.enable
 
-Enable diagnostics.
+Habilita diagnósticos.
 
 ## type
 
@@ -400,9 +445,25 @@ boolean
 true
 ```
 
+# diagnostics.enableScheme
+
+**Missing description!!**
+
+## type
+
+```ts
+Array<string>
+```
+
+## default
+
+```jsonc
+["file"]
+```
+
 # diagnostics.globals
 
-Defined global variables.
+Variáveis globais definidas.
 
 ## type
 
@@ -418,7 +479,7 @@ Array<string>
 
 # diagnostics.globalsRegex
 
-Find defined global variables using regex.
+Encontra variáveis globais definidas usando regex.
 
 ## type
 
@@ -434,14 +495,14 @@ Array<string>
 
 # diagnostics.groupFileStatus
 
-Modify the diagnostic needed file status in a group.
+Modifica o status de arquivo necessário para diagnóstico em um grupo.
 
-* Opened:  only diagnose opened files
-* Any:     diagnose all files
-* None:    disable this diagnostic
+* Opened:  diagnosticar apenas arquivos abertos
+* Any:     diagnosticar todos os arquivos
+* None:    desabilitar este diagnóstico
 
-`Fallback` means that diagnostics in this group are controlled by `diagnostics.neededFileStatus` separately.
-Other settings will override individual settings without end of `!`.
+`Fallback` significa que os diagnósticos deste grupo são controlados por `diagnostics.neededFileStatus` separadamente.
+Outras configurações sobrescreverão configurações individuais sem terminar com `!`.
 
 
 ## type
@@ -567,9 +628,9 @@ object<string, string>
 
 # diagnostics.groupSeverity
 
-Modify the diagnostic severity in a group.
-`Fallback` means that diagnostics in this group are controlled by `diagnostics.severity` separately.
-Other settings will override individual settings without end of `!`.
+Modifica a gravidade do diagnóstico em um grupo.
+`Fallback` significa que os diagnósticos deste grupo são controlados por `diagnostics.severity` separadamente.
+Outras configurações sobrescreverão configurações individuais sem terminar com `!`.
 
 
 ## type
@@ -696,7 +757,7 @@ object<string, string>
 
 # diagnostics.ignoredFiles
 
-How to diagnose ignored files.
+Como diagnosticar arquivos ignorados.
 
 ## type
 
@@ -706,9 +767,9 @@ string
 
 ## enum
 
-* ``"Enable"``: Always diagnose these files.
-* ``"Opened"``: Only when these files are opened will it be diagnosed.
-* ``"Disable"``: These files are not diagnosed.
+* ``"Enable"``: Sempre diagnosticar esses arquivos.
+* ``"Opened"``: Diagnosticar esses arquivos apenas quando estiverem abertos.
+* ``"Disable"``: Esses arquivos não são diagnosticados.
 
 ## default
 
@@ -718,7 +779,7 @@ string
 
 # diagnostics.libraryFiles
 
-How to diagnose files loaded via `Lua.workspace.library`.
+Como diagnosticar arquivos carregados via `Lua.workspace.library`.
 
 ## type
 
@@ -728,9 +789,9 @@ string
 
 ## enum
 
-* ``"Enable"``: Always diagnose these files.
-* ``"Opened"``: Only when these files are opened will it be diagnosed.
-* ``"Disable"``: These files are not diagnosed.
+* ``"Enable"``: Sempre diagnosticar esses arquivos.
+* ``"Opened"``: Diagnosticar esses arquivos apenas quando estiverem abertos.
+* ``"Disable"``: Esses arquivos não são diagnosticados.
 
 ## default
 
@@ -740,11 +801,11 @@ string
 
 # diagnostics.neededFileStatus
 
-* Opened:  only diagnose opened files
-* Any:     diagnose all files
-* None:    disable this diagnostic
+* Opened:  diagnosticar apenas arquivos abertos
+* Any:     diagnosticar todos os arquivos
+* None:    desabilitar este diagnóstico
 
-End with `!` means override the group setting `diagnostics.groupFileStatus`.
+Terminar com `!` significa sobrescrever a configuração de grupo `diagnostics.groupFileStatus`.
 
 
 ## type
@@ -767,242 +828,242 @@ object<string, string>
 ```jsonc
 {
     /*
-    优先级歧义，如：`num or 0 + 1`，推测用户的实际期望为 `(num or 0) + 1` 
+    Ambiguidade de precedência, por exemplo `num or 0 + 1`; supõe-se que o esperado seja `(num or 0) + 1`
     */
     "ambiguity-1": "Any",
     /*
-    Enable diagnostics for assignments in which the value's type does not match the type of the assigned variable.
+    Habilita diagnóstico para atribuições em que o tipo do valor não corresponde ao tipo da variável alvo.
     */
     "assign-type-mismatch": "Opened",
     /*
-    Enable diagnostics for calls of asynchronous functions within a synchronous function.
+    Habilita diagnóstico para chamadas de funções assíncronas dentro de uma função síncrona.
     */
     "await-in-sync": "None",
     /*
-    Enable diagnostics for casts of local variables where the target type does not match the defined type.
+    Habilita diagnóstico para coerções de variáveis locais em que o tipo alvo não corresponde ao tipo definido.
     */
     "cast-local-type": "Opened",
     /*
-    Enable diagnostics for casts where the target type does not match the initial type.
+    Habilita diagnóstico para coerções em que o tipo alvo não corresponde ao tipo inicial.
     */
     "cast-type-mismatch": "Opened",
     "circle-doc-class": "Any",
     /*
-    Enable diagnostics for attempts to close a variable with a non-object.
+    Habilita diagnóstico para tentativas de fechar uma variável que não é objeto.
     */
     "close-non-object": "Any",
     /*
-    Enable diagnostics for code placed after a break statement in a loop.
+    Habilita diagnóstico para código após um `break` em um loop.
     */
     "code-after-break": "Opened",
     /*
-    Enable diagnostics for incorrectly styled lines.
+    Habilita diagnóstico para linhas que violam o estilo de código.
     */
     "codestyle-check": "None",
     /*
-    Enable diagnostics for `for` loops which will never reach their max/limit because the loop is incrementing instead of decrementing.
+    Habilita diagnóstico para laços `for` decrescentes que nunca atingem o limite porque são incrementados.
     */
     "count-down-loop": "Any",
     /*
-    Enable diagnostics to highlight deprecated API.
+    Habilita diagnóstico para APIs obsoletas.
     */
     "deprecated": "Any",
     /*
-    Enable diagnostics for files which are required by two different paths.
+    Habilita diagnóstico para arquivos exigidos por dois caminhos diferentes.
     */
     "different-requires": "Any",
     /*
-    Enable diagnostics for calls of functions annotated with `---@nodiscard` where the return values are ignored.
+    Habilita diagnóstico para chamadas de funções anotadas com `---@nodiscard` quando os retornos são ignorados.
     */
     "discard-returns": "Any",
     /*
-    Enable diagnostics to highlight a field annotation without a defining class annotation.
+    Habilita diagnóstico para anotações de campo sem anotação de classe correspondente.
     */
     "doc-field-no-class": "Any",
     /*
-    Enable diagnostics for a duplicated alias annotation name.
+    Habilita diagnóstico para nome de alias anotado duplicado.
     */
     "duplicate-doc-alias": "Any",
     /*
-    Enable diagnostics for a duplicated field annotation name.
+    Habilita diagnóstico para nome de campo anotado duplicado.
     */
     "duplicate-doc-field": "Any",
     /*
-    Enable diagnostics for a duplicated param annotation name.
+    Habilita diagnóstico para nome de parâmetro anotado duplicado.
     */
     "duplicate-doc-param": "Any",
     /*
-    在字面量表中重复定义了索引
+    Índice duplicado em tabela literal
     */
     "duplicate-index": "Any",
     /*
-    Enable diagnostics for setting the same field in a class more than once.
+    Habilita diagnóstico para definir o mesmo campo em uma classe mais de uma vez.
     */
     "duplicate-set-field": "Opened",
     /*
-    空代码块
+    Bloco vazio
     */
     "empty-block": "Opened",
     /*
-    Enable diagnostics to warn about global elements.
+    Habilita diagnóstico para avisar sobre elementos globais.
     */
     "global-element": "None",
     /*
-    不能使用全局变量（ `_ENV` 被设置为了 `nil`）
+    Não é possível usar variáveis globais (`_ENV` foi definido como `nil`)
     */
     "global-in-nil-env": "Any",
     /*
-    Incomplete @param or @return annotations for functions.
+    Anotações @param ou @return incompletas para funções.
     */
     "incomplete-signature-doc": "None",
     "inject-field": "Opened",
     /*
-    Enable diagnostics for accesses to fields which are invisible.
+    Habilita diagnóstico para acessos a campos invisíveis.
     */
     "invisible": "Any",
     /*
-    首字母小写的全局变量定义
+    Definição de variável global com inicial minúscula
     */
     "lowercase-global": "Any",
     "missing-fields": "Any",
     /*
-    Missing annotations for globals! Global functions must have a comment and annotations for all parameters and return values.
+    Faltam anotações para globais! Funções globais devem ter comentário e anotações para todos os parâmetros e retornos.
     */
     "missing-global-doc": "None",
     /*
-    Missing annotations for exported locals! Exported local functions must have a comment and annotations for all parameters and return values.
+    Faltam anotações para locais exportados! Funções locais exportadas devem ter comentário e anotações para todos os parâmetros e retornos.
     */
     "missing-local-export-doc": "None",
     /*
-    Enable diagnostics for function calls where the number of arguments is less than the number of annotated function parameters.
+    Habilita diagnóstico para chamadas de função com menos argumentos que os parâmetros anotados.
     */
     "missing-parameter": "Any",
     /*
-    Enable diagnostics for functions with return annotations which have no return statement.
+    Habilita diagnóstico para funções com anotação de retorno mas sem instrução return.
     */
     "missing-return": "Any",
     /*
-    Enable diagnostics for return statements without values although the containing function declares returns.
+    Habilita diagnóstico para retornos sem valores embora a função declare valores de retorno.
     */
     "missing-return-value": "Any",
     /*
-    Enable diagnostics for name style.
+    Habilita diagnóstico para estilo de nomes.
     */
     "name-style-check": "None",
     /*
-    Enable diagnostics for variable usages if `nil` or an optional (potentially `nil`) value was assigned to the variable before.
+    Habilita diagnóstico para uso de variável após ela receber `nil` ou valor opcional.
     */
     "need-check-nil": "Opened",
     /*
-    在字面量表中，2行代码之间缺少分隔符，在语法上被解析为了一次索引操作
+    Em uma tabela literal, faltou um separador entre duas linhas; foi interpretado como uma operação de índice
     */
     "newfield-call": "Any",
     /*
-    以 `(` 开始的新行，在语法上被解析为了上一行的函数调用
+    Nova linha iniciando com `(` é analisada como chamada da linha anterior
     */
     "newline-call": "Any",
     /*
-    Enable diagnostics for cases in which the type cannot be inferred.
+    Habilita diagnóstico para casos em que o tipo não pode ser inferido.
     */
     "no-unknown": "None",
     /*
-    Enable diagnostics for calls to `coroutine.yield()` when it is not permitted.
+    Habilita diagnóstico para chamadas de `coroutine.yield()` quando não permitido.
     */
     "not-yieldable": "None",
     /*
-    Enable diagnostics for function calls where the type of a provided parameter does not match the type of the annotated function definition.
+    Habilita diagnóstico para chamadas onde o tipo do parâmetro fornecido não corresponde à definição anotada.
     */
     "param-type-mismatch": "Opened",
     /*
-    重复定义的局部变量
+    Variável local redefinida
     */
     "redefined-local": "Opened",
     /*
-    函数调用时，传入了多余的参数
+    Chamada de função com parâmetros em excesso
     */
     "redundant-parameter": "Any",
     /*
-    Enable diagnostics for return statements which are not needed because the function would exit on its own.
+    Habilita diagnóstico para retornos desnecessários porque a função já terminaria.
     */
     "redundant-return": "Opened",
     /*
-    Enable diagnostics for return statements which return an extra value which is not specified by a return annotation.
+    Habilita diagnóstico para retornos que entregam valor extra não especificado na anotação.
     */
     "redundant-return-value": "Any",
     /*
-    赋值操作时，值的数量比被赋值的对象多
+    Em uma atribuição, há mais valores que variáveis-alvo
     */
     "redundant-value": "Any",
     /*
-    Enable diagnostics for return values whose type does not match the type declared in the corresponding return annotation.
+    Habilita diagnóstico para retornos cujo tipo não corresponde ao tipo declarado.
     */
     "return-type-mismatch": "Opened",
     /*
-    Enable diagnostics for typos in strings.
+    Habilita diagnóstico para erros ortográficos em strings.
     */
     "spell-check": "None",
     /*
-    后置空格
+    Espaços à direita
     */
     "trailing-space": "Opened",
     /*
-    Enable diagnostics on multiple assignments if not all variables obtain a value (e.g., `local x,y = 1`).
+    Habilita diagnóstico em múltiplas atribuições se nem todas as variáveis recebem valor (ex.: `local x,y = 1`).
     */
     "unbalanced-assignments": "Any",
     /*
-    Enable diagnostics for class annotations in which an undefined class is referenced.
+    Habilita diagnóstico para anotações de classe que fazem referência a classe indefinida.
     */
     "undefined-doc-class": "Any",
     /*
-    Enable diagnostics for type annotations referencing an undefined type or alias.
+    Habilita diagnóstico para anotações de tipo que referenciam tipo ou alias indefinido.
     */
     "undefined-doc-name": "Any",
     /*
-    Enable diagnostics for cases in which a parameter annotation is given without declaring the parameter in the function definition.
+    Habilita diagnóstico para anotações de parâmetro sem declaração correspondente na função.
     */
     "undefined-doc-param": "Any",
     /*
-    `_ENV` 被设置为了新的字面量表，但是试图获取的全局变量不再这张表中
+    `_ENV` foi definido como nova tabela literal, mas a variável global acessada não está nela
     */
     "undefined-env-child": "Any",
     /*
-    Enable diagnostics for cases in which an undefined field of a variable is read.
+    Habilita diagnóstico para leitura de campo indefinido de uma variável.
     */
     "undefined-field": "Opened",
     /*
-    未定义的全局变量
+    Variável global não definida
     */
     "undefined-global": "Any",
     /*
-    Enable diagnostics for casts of undefined variables.
+    Habilita diagnóstico para coerções de variáveis indefinidas.
     */
     "unknown-cast-variable": "Any",
     /*
-    Enable diagnostics in cases in which an unknown diagnostics code is entered.
+    Habilita diagnóstico quando um código de diagnóstico desconhecido é informado.
     */
     "unknown-diag-code": "Any",
     /*
-    Enable diagnostics for unknown operators.
+    Habilita diagnóstico para operadores desconhecidos.
     */
     "unknown-operator": "Any",
     /*
-    Enable diagnostics for unreachable code.
+    Habilita diagnóstico para código inalcançável.
     */
     "unreachable-code": "Opened",
     /*
-    未使用的函数
+    Função não utilizada
     */
     "unused-function": "Opened",
     /*
-    未使用的标签
+    Rótulo não utilizado
     */
     "unused-label": "Opened",
     /*
-    未使用的局部变量
+    Variável local não utilizada
     */
     "unused-local": "Opened",
     /*
-    未使用的不定参数
+    Parâmetro vararg não utilizado
     */
     "unused-vararg": "Opened"
 }
@@ -1010,9 +1071,9 @@ object<string, string>
 
 # diagnostics.severity
 
-Modify the diagnostic severity.
+Modifica a gravidade do diagnóstico.
 
-End with `!` means override the group setting `diagnostics.groupSeverity`.
+Terminar com `!` significa sobrescrever a configuração de grupo `diagnostics.groupSeverity`.
 
 
 ## type
@@ -1037,242 +1098,242 @@ object<string, string>
 ```jsonc
 {
     /*
-    优先级歧义，如：`num or 0 + 1`，推测用户的实际期望为 `(num or 0) + 1` 
+    Ambiguidade de precedência, por exemplo `num or 0 + 1`; supõe-se que o esperado seja `(num or 0) + 1`
     */
     "ambiguity-1": "Warning",
     /*
-    Enable diagnostics for assignments in which the value's type does not match the type of the assigned variable.
+    Habilita diagnóstico para atribuições em que o tipo do valor não corresponde ao tipo da variável alvo.
     */
     "assign-type-mismatch": "Warning",
     /*
-    Enable diagnostics for calls of asynchronous functions within a synchronous function.
+    Habilita diagnóstico para chamadas de funções assíncronas dentro de uma função síncrona.
     */
     "await-in-sync": "Warning",
     /*
-    Enable diagnostics for casts of local variables where the target type does not match the defined type.
+    Habilita diagnóstico para coerções de variáveis locais em que o tipo alvo não corresponde ao tipo definido.
     */
     "cast-local-type": "Warning",
     /*
-    Enable diagnostics for casts where the target type does not match the initial type.
+    Habilita diagnóstico para coerções em que o tipo alvo não corresponde ao tipo inicial.
     */
     "cast-type-mismatch": "Warning",
     "circle-doc-class": "Warning",
     /*
-    Enable diagnostics for attempts to close a variable with a non-object.
+    Habilita diagnóstico para tentativas de fechar uma variável que não é objeto.
     */
     "close-non-object": "Warning",
     /*
-    Enable diagnostics for code placed after a break statement in a loop.
+    Habilita diagnóstico para código após um `break` em um loop.
     */
     "code-after-break": "Hint",
     /*
-    Enable diagnostics for incorrectly styled lines.
+    Habilita diagnóstico para linhas que violam o estilo de código.
     */
     "codestyle-check": "Warning",
     /*
-    Enable diagnostics for `for` loops which will never reach their max/limit because the loop is incrementing instead of decrementing.
+    Habilita diagnóstico para laços `for` decrescentes que nunca atingem o limite porque são incrementados.
     */
     "count-down-loop": "Warning",
     /*
-    Enable diagnostics to highlight deprecated API.
+    Habilita diagnóstico para APIs obsoletas.
     */
     "deprecated": "Warning",
     /*
-    Enable diagnostics for files which are required by two different paths.
+    Habilita diagnóstico para arquivos exigidos por dois caminhos diferentes.
     */
     "different-requires": "Warning",
     /*
-    Enable diagnostics for calls of functions annotated with `---@nodiscard` where the return values are ignored.
+    Habilita diagnóstico para chamadas de funções anotadas com `---@nodiscard` quando os retornos são ignorados.
     */
     "discard-returns": "Warning",
     /*
-    Enable diagnostics to highlight a field annotation without a defining class annotation.
+    Habilita diagnóstico para anotações de campo sem anotação de classe correspondente.
     */
     "doc-field-no-class": "Warning",
     /*
-    Enable diagnostics for a duplicated alias annotation name.
+    Habilita diagnóstico para nome de alias anotado duplicado.
     */
     "duplicate-doc-alias": "Warning",
     /*
-    Enable diagnostics for a duplicated field annotation name.
+    Habilita diagnóstico para nome de campo anotado duplicado.
     */
     "duplicate-doc-field": "Warning",
     /*
-    Enable diagnostics for a duplicated param annotation name.
+    Habilita diagnóstico para nome de parâmetro anotado duplicado.
     */
     "duplicate-doc-param": "Warning",
     /*
-    在字面量表中重复定义了索引
+    Índice duplicado em tabela literal
     */
     "duplicate-index": "Warning",
     /*
-    Enable diagnostics for setting the same field in a class more than once.
+    Habilita diagnóstico para definir o mesmo campo em uma classe mais de uma vez.
     */
     "duplicate-set-field": "Warning",
     /*
-    空代码块
+    Bloco vazio
     */
     "empty-block": "Hint",
     /*
-    Enable diagnostics to warn about global elements.
+    Habilita diagnóstico para avisar sobre elementos globais.
     */
     "global-element": "Warning",
     /*
-    不能使用全局变量（ `_ENV` 被设置为了 `nil`）
+    Não é possível usar variáveis globais (`_ENV` foi definido como `nil`)
     */
     "global-in-nil-env": "Warning",
     /*
-    Incomplete @param or @return annotations for functions.
+    Anotações @param ou @return incompletas para funções.
     */
     "incomplete-signature-doc": "Warning",
     "inject-field": "Warning",
     /*
-    Enable diagnostics for accesses to fields which are invisible.
+    Habilita diagnóstico para acessos a campos invisíveis.
     */
     "invisible": "Warning",
     /*
-    首字母小写的全局变量定义
+    Definição de variável global com inicial minúscula
     */
     "lowercase-global": "Information",
     "missing-fields": "Warning",
     /*
-    Missing annotations for globals! Global functions must have a comment and annotations for all parameters and return values.
+    Faltam anotações para globais! Funções globais devem ter comentário e anotações para todos os parâmetros e retornos.
     */
     "missing-global-doc": "Warning",
     /*
-    Missing annotations for exported locals! Exported local functions must have a comment and annotations for all parameters and return values.
+    Faltam anotações para locais exportados! Funções locais exportadas devem ter comentário e anotações para todos os parâmetros e retornos.
     */
     "missing-local-export-doc": "Warning",
     /*
-    Enable diagnostics for function calls where the number of arguments is less than the number of annotated function parameters.
+    Habilita diagnóstico para chamadas de função com menos argumentos que os parâmetros anotados.
     */
     "missing-parameter": "Warning",
     /*
-    Enable diagnostics for functions with return annotations which have no return statement.
+    Habilita diagnóstico para funções com anotação de retorno mas sem instrução return.
     */
     "missing-return": "Warning",
     /*
-    Enable diagnostics for return statements without values although the containing function declares returns.
+    Habilita diagnóstico para retornos sem valores embora a função declare valores de retorno.
     */
     "missing-return-value": "Warning",
     /*
-    Enable diagnostics for name style.
+    Habilita diagnóstico para estilo de nomes.
     */
     "name-style-check": "Warning",
     /*
-    Enable diagnostics for variable usages if `nil` or an optional (potentially `nil`) value was assigned to the variable before.
+    Habilita diagnóstico para uso de variável após ela receber `nil` ou valor opcional.
     */
     "need-check-nil": "Warning",
     /*
-    在字面量表中，2行代码之间缺少分隔符，在语法上被解析为了一次索引操作
+    Em uma tabela literal, faltou um separador entre duas linhas; foi interpretado como uma operação de índice
     */
     "newfield-call": "Warning",
     /*
-    以 `(` 开始的新行，在语法上被解析为了上一行的函数调用
+    Nova linha iniciando com `(` é analisada como chamada da linha anterior
     */
     "newline-call": "Warning",
     /*
-    Enable diagnostics for cases in which the type cannot be inferred.
+    Habilita diagnóstico para casos em que o tipo não pode ser inferido.
     */
     "no-unknown": "Warning",
     /*
-    Enable diagnostics for calls to `coroutine.yield()` when it is not permitted.
+    Habilita diagnóstico para chamadas de `coroutine.yield()` quando não permitido.
     */
     "not-yieldable": "Warning",
     /*
-    Enable diagnostics for function calls where the type of a provided parameter does not match the type of the annotated function definition.
+    Habilita diagnóstico para chamadas onde o tipo do parâmetro fornecido não corresponde à definição anotada.
     */
     "param-type-mismatch": "Warning",
     /*
-    重复定义的局部变量
+    Variável local redefinida
     */
     "redefined-local": "Hint",
     /*
-    函数调用时，传入了多余的参数
+    Chamada de função com parâmetros em excesso
     */
     "redundant-parameter": "Warning",
     /*
-    Enable diagnostics for return statements which are not needed because the function would exit on its own.
+    Habilita diagnóstico para retornos desnecessários porque a função já terminaria.
     */
     "redundant-return": "Hint",
     /*
-    Enable diagnostics for return statements which return an extra value which is not specified by a return annotation.
+    Habilita diagnóstico para retornos que entregam valor extra não especificado na anotação.
     */
     "redundant-return-value": "Warning",
     /*
-    赋值操作时，值的数量比被赋值的对象多
+    Em uma atribuição, há mais valores que variáveis-alvo
     */
     "redundant-value": "Warning",
     /*
-    Enable diagnostics for return values whose type does not match the type declared in the corresponding return annotation.
+    Habilita diagnóstico para retornos cujo tipo não corresponde ao tipo declarado.
     */
     "return-type-mismatch": "Warning",
     /*
-    Enable diagnostics for typos in strings.
+    Habilita diagnóstico para erros ortográficos em strings.
     */
     "spell-check": "Information",
     /*
-    后置空格
+    Espaços à direita
     */
     "trailing-space": "Hint",
     /*
-    Enable diagnostics on multiple assignments if not all variables obtain a value (e.g., `local x,y = 1`).
+    Habilita diagnóstico em múltiplas atribuições se nem todas as variáveis recebem valor (ex.: `local x,y = 1`).
     */
     "unbalanced-assignments": "Warning",
     /*
-    Enable diagnostics for class annotations in which an undefined class is referenced.
+    Habilita diagnóstico para anotações de classe que fazem referência a classe indefinida.
     */
     "undefined-doc-class": "Warning",
     /*
-    Enable diagnostics for type annotations referencing an undefined type or alias.
+    Habilita diagnóstico para anotações de tipo que referenciam tipo ou alias indefinido.
     */
     "undefined-doc-name": "Warning",
     /*
-    Enable diagnostics for cases in which a parameter annotation is given without declaring the parameter in the function definition.
+    Habilita diagnóstico para anotações de parâmetro sem declaração correspondente na função.
     */
     "undefined-doc-param": "Warning",
     /*
-    `_ENV` 被设置为了新的字面量表，但是试图获取的全局变量不再这张表中
+    `_ENV` foi definido como nova tabela literal, mas a variável global acessada não está nela
     */
     "undefined-env-child": "Information",
     /*
-    Enable diagnostics for cases in which an undefined field of a variable is read.
+    Habilita diagnóstico para leitura de campo indefinido de uma variável.
     */
     "undefined-field": "Warning",
     /*
-    未定义的全局变量
+    Variável global não definida
     */
     "undefined-global": "Warning",
     /*
-    Enable diagnostics for casts of undefined variables.
+    Habilita diagnóstico para coerções de variáveis indefinidas.
     */
     "unknown-cast-variable": "Warning",
     /*
-    Enable diagnostics in cases in which an unknown diagnostics code is entered.
+    Habilita diagnóstico quando um código de diagnóstico desconhecido é informado.
     */
     "unknown-diag-code": "Warning",
     /*
-    Enable diagnostics for unknown operators.
+    Habilita diagnóstico para operadores desconhecidos.
     */
     "unknown-operator": "Warning",
     /*
-    Enable diagnostics for unreachable code.
+    Habilita diagnóstico para código inalcançável.
     */
     "unreachable-code": "Hint",
     /*
-    未使用的函数
+    Função não utilizada
     */
     "unused-function": "Hint",
     /*
-    未使用的标签
+    Rótulo não utilizado
     */
     "unused-label": "Hint",
     /*
-    未使用的局部变量
+    Variável local não utilizada
     */
     "unused-local": "Hint",
     /*
-    未使用的不定参数
+    Parâmetro vararg não utilizado
     */
     "unused-vararg": "Hint"
 }
@@ -1280,7 +1341,7 @@ object<string, string>
 
 # diagnostics.unusedLocalExclude
 
-Do not diagnose `unused-local` when the variable name matches the following pattern.
+Não diagnosticar `unused-local` quando o nome da variável corresponder ao padrão a seguir.
 
 ## type
 
@@ -1296,7 +1357,7 @@ Array<string>
 
 # diagnostics.workspaceDelay
 
-Latency (milliseconds) for workspace diagnostics.
+Latência (milissegundos) para diagnósticos da workspace.
 
 ## type
 
@@ -1312,7 +1373,7 @@ integer
 
 # diagnostics.workspaceEvent
 
-Set the time to trigger workspace diagnostics.
+Define quando acionar diagnósticos da workspace.
 
 ## type
 
@@ -1322,9 +1383,9 @@ string
 
 ## enum
 
-* ``"OnChange"``: Trigger workspace diagnostics when the file is changed.
-* ``"OnSave"``: Trigger workspace diagnostics when the file is saved.
-* ``"None"``: Disable workspace diagnostics.
+* ``"OnChange"``: Aciona diagnósticos da workspace quando o arquivo é modificado.
+* ``"OnSave"``: Aciona diagnósticos da workspace quando o arquivo é salvo.
+* ``"None"``: Desabilita diagnósticos da workspace.
 
 ## default
 
@@ -1334,7 +1395,7 @@ string
 
 # diagnostics.workspaceRate
 
-Workspace diagnostics run rate (%). Decreasing this value reduces CPU usage, but also reduces the speed of workspace diagnostics. The diagnosis of the file you are currently editing is always done at full speed and is not affected by this setting.
+Taxa de execução dos diagnósticos da workspace (%). Diminuir este valor reduz o uso de CPU, mas também reduz a velocidade dos diagnósticos. O diagnóstico do arquivo que você está editando sempre é feito em velocidade total e não é afetado por esta configuração.
 
 ## type
 
@@ -1350,7 +1411,7 @@ integer
 
 # doc.packageName
 
-Treat specific field names as package, e.g. `m_*` means `XXX.m_id` and `XXX.m_type` are package, witch can only be accessed in the file where the definition is located.
+Tratar nomes de campos específicos como de pacote; ex.: `m_*` significa que `XXX.m_id` e `XXX.m_type` são de pacote e só podem ser acessados no arquivo onde foram definidos.
 
 ## type
 
@@ -1366,7 +1427,7 @@ Array<string>
 
 # doc.privateName
 
-Treat specific field names as private, e.g. `m_*` means `XXX.m_id` and `XXX.m_type` are private, witch can only be accessed in the class where the definition is located.
+Tratar nomes de campos específicos como privados; ex.: `m_*` significa que `XXX.m_id` e `XXX.m_type` são privados e só podem ser acessados na classe onde foram definidos.
 
 ## type
 
@@ -1382,7 +1443,7 @@ Array<string>
 
 # doc.protectedName
 
-Treat specific field names as protected, e.g. `m_*` means `XXX.m_id` and `XXX.m_type` are protected, witch can only be accessed in the class where the definition is located and its subclasses.
+Tratar nomes de campos específicos como protegidos; ex.: `m_*` significa que `XXX.m_id` e `XXX.m_type` são protegidos e só podem ser acessados na classe onde foram definidos e em subclasses.
 
 ## type
 
@@ -1396,10 +1457,47 @@ Array<string>
 []
 ```
 
+# doc.regengine
+
+Mecanismo de expressão regular usado para corresponder nomes de escopo de documentação.
+
+## type
+
+```ts
+string
+```
+
+## enum
+
+* ``"glob"``: Sintaxe de padrão leve padrão.
+* ``"lua"``: Expressões regulares completas no estilo Lua.
+
+## default
+
+```jsonc
+"glob"
+```
+
+# docScriptPath
+
+Mecanismo de expressão regular usado para corresponder nomes de escopo de documentação.
+
+## type
+
+```ts
+string
+```
+
+## default
+
+```jsonc
+""
+```
+
 # format.defaultConfig
 
-The default format configuration. Has a lower priority than `.editorconfig` file in the workspace.
-Read [formatter docs](https://github.com/CppCXY/EmmyLuaCodeStyle/tree/master/docs) to learn usage.
+Configuração de formatação padrão; tem prioridade menor que o arquivo `.editorconfig` da workspace.
+Consulte a [documentação do formatador](https://github.com/CppCXY/EmmyLuaCodeStyle/tree/master/docs) para uso.
 
 
 ## type
@@ -1416,7 +1514,7 @@ Object<string, string>
 
 # format.enable
 
-Enable code formatter.
+Habilitar formatador de código.
 
 ## type
 
@@ -1432,7 +1530,7 @@ true
 
 # hint.arrayIndex
 
-Show hints of array index when constructing a table.
+Mostrar dicas de índice de array ao construir uma tabela.
 
 ## type
 
@@ -1442,9 +1540,9 @@ string
 
 ## enum
 
-* ``"Enable"``: Show hints in all tables.
-* ``"Auto"``: Show hints only when the table is greater than 3 items, or the table is a mixed table.
-* ``"Disable"``: Disable hints of array index.
+* ``"Enable"``: Mostrar dicas em todas as tabelas.
+* ``"Auto"``: Mostrar dicas apenas quando a tabela tiver mais de 3 itens ou for uma tabela mista.
+* ``"Disable"``: Desativar dicas de índice de array.
 
 ## default
 
@@ -1454,7 +1552,7 @@ string
 
 # hint.await
 
-If the called function is marked `---@async`, prompt `await` at the call.
+Se a função chamada estiver marcada com `---@async`, sugerir `await` na chamada.
 
 ## type
 
@@ -1468,9 +1566,25 @@ boolean
 true
 ```
 
+# hint.awaitPropagate
+
+Habilita a propagação de `await`. Quando uma função chama outra marcada com `---@async`, ela será automaticamente marcada como `---@async`.
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+false
+```
+
 # hint.enable
 
-Enable inlay hint.
+Habilitar inlay hints.
 
 ## type
 
@@ -1486,7 +1600,7 @@ false
 
 # hint.paramName
 
-Show hints of parameter name at the function call.
+Mostrar dicas com o nome do parâmetro na chamada de função.
 
 ## type
 
@@ -1496,9 +1610,9 @@ string
 
 ## enum
 
-* ``"All"``: All types of parameters are shown.
-* ``"Literal"``: Only literal type parameters are shown.
-* ``"Disable"``: Disable parameter hints.
+* ``"All"``: Mostrar todos os tipos de parâmetros.
+* ``"Literal"``: Mostrar apenas parâmetros de tipo literal.
+* ``"Disable"``: Desativar dicas de nome de parâmetro.
 
 ## default
 
@@ -1508,7 +1622,7 @@ string
 
 # hint.paramType
 
-Show type hints at the parameter of the function.
+Mostrar dicas de tipo nos parâmetros da função.
 
 ## type
 
@@ -1524,7 +1638,7 @@ true
 
 # hint.semicolon
 
-If there is no semicolon at the end of the statement, display a virtual semicolon.
+Se não houver ponto e vírgula no fim da instrução, mostrar um ponto e vírgula virtual.
 
 ## type
 
@@ -1534,9 +1648,9 @@ string
 
 ## enum
 
-* ``"All"``: All statements display virtual semicolons.
-* ``"SameLine"``: When two statements are on the same line, display a semicolon between them.
-* ``"Disable"``: Disable virtual semicolons.
+* ``"All"``: Todas as instruções exibem ponto e vírgula virtual.
+* ``"SameLine"``: Quando duas instruções estiverem na mesma linha, mostrar um ponto e vírgula entre elas.
+* ``"Disable"``: Desativar pontos e vírgulas virtuais.
 
 ## default
 
@@ -1546,7 +1660,7 @@ string
 
 # hint.setType
 
-Show hints of type at assignment operation.
+Mostrar dicas de tipo em atribuições.
 
 ## type
 
@@ -1562,7 +1676,7 @@ false
 
 # hover.enable
 
-Enable hover.
+Habilitar hover.
 
 ## type
 
@@ -1578,7 +1692,7 @@ true
 
 # hover.enumsLimit
 
-When the value corresponds to multiple types, limit the number of types displaying.
+Quando um valor corresponde a vários tipos, limita quantos tipos são exibidos.
 
 ## type
 
@@ -1594,7 +1708,7 @@ integer
 
 # hover.expandAlias
 
-Whether to expand the alias. For example, expands `---@alias myType boolean|number` appears as `boolean|number`, otherwise it appears as `myType'.
+Definir se aliases devem ser expandidos. Por exemplo, `---@alias myType boolean|number` aparecerá como `boolean|number`; caso contrário aparecerá como `myType`.
 
 
 ## type
@@ -1611,7 +1725,7 @@ true
 
 # hover.previewFields
 
-When hovering to view a table, limits the maximum number of previews for fields.
+Ao inspecionar uma tabela, limita o número máximo de campos pré-visualizados.
 
 ## type
 
@@ -1622,12 +1736,12 @@ integer
 ## default
 
 ```jsonc
-50
+10
 ```
 
 # hover.viewNumber
 
-Hover to view numeric content (only if literal is not decimal).
+No hover, mostrar conteúdo numérico (apenas se o literal não for decimal).
 
 ## type
 
@@ -1643,7 +1757,7 @@ true
 
 # hover.viewString
 
-Hover to view the contents of a string (only if the literal contains an escape character).
+No hover, mostrar o conteúdo da string (apenas se o literal tiver caracteres de escape).
 
 ## type
 
@@ -1659,7 +1773,7 @@ true
 
 # hover.viewStringMax
 
-The maximum length of a hover to view the contents of a string.
+Comprimento máximo da string exibida no hover.
 
 ## type
 
@@ -1673,9 +1787,41 @@ integer
 1000
 ```
 
+# language.completeAnnotation
+
+(Somente VSCode) Insere automaticamente "---@ " após uma quebra de linha seguinte a uma anotação.
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+true
+```
+
+# language.fixIndent
+
+(Somente VSCode) Corrige indentação automática incorreta, como quebras de linha dentro de uma string contendo a palavra "function".
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+true
+```
+
 # misc.executablePath
 
-Specify the executable path in VSCode.
+Especifica o caminho do executável no VSCode.
 
 ## type
 
@@ -1691,7 +1837,7 @@ string
 
 # misc.parameters
 
-[Command line parameters](https://github.com/LuaLS/lua-telemetry-server/tree/master/method) when starting the language service in VSCode.
+[Parâmetros de linha de comando](https://github.com/LuaLS/lua-telemetry-server/tree/master/method) ao iniciar o serviço de linguagem no VSCode.
 
 ## type
 
@@ -1707,7 +1853,9 @@ Array<string>
 
 # nameStyle.config
 
-Set name style config
+Configurações de estilo de nomes.
+Consulte a [documentação do formatador](https://github.com/CppCXY/EmmyLuaCodeStyle/tree/master/docs) para uso.
+
 
 ## type
 
@@ -1723,11 +1871,11 @@ Object<string, string | array>
 
 # runtime.builtin
 
-Adjust the enabled state of the built-in library. You can disable (or redefine) the non-existent library according to the actual runtime environment.
+Ajusta o estado de habilitação das bibliotecas internas. Você pode desabilitar (ou redefinir) bibliotecas inexistentes conforme o ambiente de execução real.
 
-* `default`: Indicates that the library will be enabled or disabled according to the runtime version
-* `enable`: always enable
-* `disable`: always disable
+* `default`: a biblioteca será habilitada ou desabilitada conforme a versão do runtime
+* `enable`: sempre habilitar
+* `disable`: sempre desabilitar
 
 
 ## type
@@ -1771,7 +1919,7 @@ object<string, string>
 
 # runtime.fileEncoding
 
-File encoding. The `ansi` option is only available under the `Windows` platform.
+Codificação de arquivo. A opção `ansi` está disponível apenas na plataforma `Windows`.
 
 ## type
 
@@ -1794,7 +1942,7 @@ string
 
 # runtime.meta
 
-Format of the directory name of the meta files.
+Formato do nome do diretório dos arquivos meta.
 
 ## type
 
@@ -1810,7 +1958,7 @@ string
 
 # runtime.nonstandardSymbol
 
-Supports non-standard symbols. Make sure that your runtime environment supports these symbols.
+Suporta símbolos não-padrão. Certifique-se de que seu ambiente de runtime suporta esses símbolos.
 
 ## type
 
@@ -1849,10 +1997,10 @@ Array<string>
 
 # runtime.path
 
-When using `require`, how to find the file based on the input name.
-Setting this config to `?/init.lua` means that when you enter `require 'myfile'`, `${workspace}/myfile/init.lua` will be searched from the loaded files.
-if `runtime.pathStrict` is `false`, `${workspace}/**/myfile/init.lua` will also be searched.
-If you want to load files outside the workspace, you need to set `Lua.workspace.library` first.
+Ao usar `require`, define como encontrar o arquivo baseado no nome fornecido.
+Definir esta configuração como `?/init.lua` significa que ao executar `require 'myfile'`, será buscado `${workspace}/myfile/init.lua` nos arquivos carregados.
+Se `runtime.pathStrict` for `false`, `${workspace}/**/myfile/init.lua` também será buscado.
+Para carregar arquivos fora da workspace, primeiro configure `Lua.workspace.library`.
 
 
 ## type
@@ -1869,7 +2017,7 @@ Array<string>
 
 # runtime.pathStrict
 
-When enabled, `runtime.path` will only search the first level of directories, see the description of `runtime.path`.
+Quando habilitado, `runtime.path` buscará apenas o primeiro nível de diretórios; veja a descrição de `runtime.path`.
 
 ## type
 
@@ -1885,40 +2033,40 @@ false
 
 # runtime.plugin
 
-Plugin path. Please read [wiki](https://luals.github.io/wiki/plugins) to learn more.
+Caminho do plugin. Leia a [wiki](https://luals.github.io/wiki/plugins) para saber mais.
 
 ## type
 
 ```ts
-string
+string | array
 ```
 
 ## default
 
 ```jsonc
-""
+null
 ```
 
 # runtime.pluginArgs
 
-Additional arguments for the plugin.
+Argumentos adicionais para o plugin.
 
 ## type
 
 ```ts
-Array<string>
+array | object
 ```
 
 ## default
 
 ```jsonc
-[]
+null
 ```
 
 # runtime.special
 
-The custom global variables are regarded as some special built-in variables, and the language server will provide special support
-The following example shows that 'include' is treated as' require '.
+Variáveis globais personalizadas são tratadas como variáveis especiais internas, e o servidor fornecerá suporte especial.
+O exemplo a seguir mostra que 'include' é tratado como 'require'.
 ```json
 "Lua.runtime.special" : {
     "include" : "require"
@@ -1940,7 +2088,7 @@ Object<string, string>
 
 # runtime.unicodeName
 
-Allows Unicode characters in name.
+Permite caracteres Unicode em nomes.
 
 ## type
 
@@ -1956,7 +2104,7 @@ false
 
 # runtime.version
 
-Lua runtime version.
+Versão do runtime Lua.
 
 ## type
 
@@ -1970,6 +2118,7 @@ string
 * ``"Lua 5.2"``
 * ``"Lua 5.3"``
 * ``"Lua 5.4"``
+* ``"Lua 5.5"``
 * ``"LuaJIT"``
 
 ## default
@@ -1980,7 +2129,7 @@ string
 
 # semantic.annotation
 
-Semantic coloring of type annotations.
+Colorização semântica de anotações de tipo.
 
 ## type
 
@@ -1996,7 +2145,7 @@ true
 
 # semantic.enable
 
-Enable semantic color. You may need to set `editor.semanticHighlighting.enabled` to `true` to take effect.
+Habilita colorização semântica. Pode ser necessário definir `editor.semanticHighlighting.enabled` como `true`.
 
 ## type
 
@@ -2012,7 +2161,7 @@ true
 
 # semantic.keyword
 
-Semantic coloring of keywords/literals/operators. You only need to enable this feature if your editor cannot do syntax coloring.
+Colorização semântica de palavras-chave/literais/operadores. Só habilite se seu editor não oferecer colorização sintática.
 
 ## type
 
@@ -2028,7 +2177,7 @@ false
 
 # semantic.variable
 
-Semantic coloring of variables/fields/parameters.
+Colorização semântica de variáveis/campos/parâmetros.
 
 ## type
 
@@ -2044,7 +2193,7 @@ true
 
 # signatureHelp.enable
 
-Enable signature help.
+Habilitar ajuda de assinatura.
 
 ## type
 
@@ -2060,7 +2209,7 @@ true
 
 # spell.dict
 
-Custom words for spell checking.
+Palavras personalizadas para verificação ortográfica.
 
 ## type
 
@@ -2076,7 +2225,7 @@ Array<string>
 
 # type.castNumberToInteger
 
-Allowed to assign the `number` type to the `integer` type.
+Permitir atribuir o tipo `number` ao tipo `integer`.
 
 ## type
 
@@ -2090,11 +2239,79 @@ boolean
 true
 ```
 
+# type.checkTableShape
+
+Verificação rigorosa do formato das tabelas.
+
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+false
+```
+
+# type.inferParamType
+
+Quando o parâmetro não tiver anotação, inferir o tipo a partir dos argumentos de chamada.
+
+Quando esta opção for `false`, o tipo do parâmetro será `any` se não houver anotação.
+
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+false
+```
+
+# type.inferTableSize
+
+Número máximo de campos de tabela analisados durante a inferência de tipo.
+
+## type
+
+```ts
+integer
+```
+
+## default
+
+```jsonc
+10
+```
+
+# type.maxUnionVariants
+
+**Missing description!!**
+
+## type
+
+```ts
+integer
+```
+
+## default
+
+```jsonc
+0
+```
+
 # type.weakNilCheck
 
-When checking the type of union type, ignore the `nil` in it.
+Ao verificar um tipo união, ignora o `nil` presente nele.
 
-When this setting is `false`, the `number|nil` type cannot be assigned to the `number` type. It can be with `true`.
+Quando esta opção for `false`, `number|nil` não pode ser atribuído a `number`; com `true`, pode.
 
 
 ## type
@@ -2111,9 +2328,9 @@ false
 
 # type.weakUnionCheck
 
-Once one subtype of a union type meets the condition, the union type also meets the condition.
+Quando um subtipo de uma união atende à condição, considera-se que a união inteira atende.
 
-When this setting is `false`, the `number|boolean` type cannot be assigned to the `number` type. It can be with `true`.
+Quando esta opção for `false`, `number|boolean` não pode ser atribuído a `number`; com `true`, pode.
 
 
 ## type
@@ -2130,7 +2347,7 @@ false
 
 # typeFormat.config
 
-Configures the formatting behavior while typing Lua code.
+Configura o comportamento de formatação enquanto digita código Lua.
 
 ## type
 
@@ -2143,15 +2360,15 @@ object<string, string>
 ```jsonc
 {
     /*
-    Controls if `end` is automatically completed at suitable positions.
+    Controla se `end` é completado automaticamente em posições adequadas.
     */
     "auto_complete_end": "true",
     /*
-    Controls if a separator is automatically appended at the end of a table declaration.
+    Controla se um separador é adicionado automaticamente ao final de uma declaração de tabela.
     */
     "auto_complete_table_sep": "true",
     /*
-    Controls if a line is formatted at all.
+    Controla se uma linha deve ser formatada.
     */
     "format_line": "true"
 }
@@ -2159,7 +2376,7 @@ object<string, string>
 
 # window.progressBar
 
-Show progress bar in status bar.
+Mostrar barra de progresso na barra de status.
 
 ## type
 
@@ -2175,7 +2392,7 @@ true
 
 # window.statusBar
 
-Show extension status in status bar.
+Mostrar status da extensão na barra de status.
 
 ## type
 
@@ -2191,7 +2408,7 @@ true
 
 # workspace.checkThirdParty
 
-Automatic detection and adaptation of third-party libraries, currently supported libraries are:
+Detecção e adaptação automáticas de bibliotecas de terceiros; atualmente suportadas:
 
 * OpenResty
 * Cocos4.0
@@ -2204,25 +2421,34 @@ Automatic detection and adaptation of third-party libraries, currently supported
 ## type
 
 ```ts
-string
+string | boolean
 ```
-
-## enum
-
-* ``"Ask"``
-* ``"Apply"``
-* ``"ApplyInMemory"``
-* ``"Disable"``
 
 ## default
 
 ```jsonc
-"Ask"
+null
+```
+
+# workspace.dofileRoots
+
+In addition to the current workspace, which directories `dofile` will treat as a possible root. The files in these directories will be loaded immediately.
+
+## type
+
+```ts
+Array<string>
+```
+
+## default
+
+```jsonc
+[]
 ```
 
 # workspace.ignoreDir
 
-Ignored files and directories (Use `.gitignore` grammar).
+Arquivos e diretórios ignorados (usa sintaxe `.gitignore`).
 
 ## type
 
@@ -2238,7 +2464,7 @@ Array<string>
 
 # workspace.ignoreSubmodules
 
-Ignore submodules.
+Ignorar submódulos.
 
 ## type
 
@@ -2254,7 +2480,7 @@ true
 
 # workspace.library
 
-In addition to the current workspace, which directories will load files from. The files in these directories will be treated as externally provided code libraries, and some features (such as renaming fields) will not modify these files.
+Além da workspace atual, de quais diretórios carregar arquivos. Os arquivos nesses diretórios serão tratados como bibliotecas de código externas, e alguns recursos (como renomear campos) não modificarão esses arquivos.
 
 ## type
 
@@ -2270,7 +2496,7 @@ Array<string>
 
 # workspace.maxPreload
 
-Max preloaded files.
+Número máximo de arquivos pré-carregados.
 
 ## type
 
@@ -2286,7 +2512,7 @@ integer
 
 # workspace.preloadFileSize
 
-Skip files larger than this value (KB) when preloading.
+Ignorar arquivos maiores que este valor (KB) ao pré-carregar.
 
 ## type
 
@@ -2302,7 +2528,7 @@ integer
 
 # workspace.useGitIgnore
 
-Ignore files list in `.gitignore` .
+Ignorar lista de arquivos em `.gitignore`.
 
 ## type
 
@@ -2318,7 +2544,7 @@ true
 
 # workspace.userThirdParty
 
-Add private third-party library configuration file paths here, please refer to the built-in [configuration file path](https://github.com/LuaLS/lua-language-server/tree/master/meta/3rd)
+Adicione aqui caminhos de configuração de bibliotecas de terceiros privadas; consulte o [caminho de configuração](https://github.com/LuaLS/lua-language-server/tree/master/meta/3rd) embutido.
 
 ## type
 

--- a/doc/zh-cn/config.md
+++ b/doc/zh-cn/config.md
@@ -1,6 +1,6 @@
 # addonManager.enable
 
-Whether the addon manager is enabled or not.
+是否启用扩展的附加插件管理器(Addon Manager)
 
 ## type
 
@@ -14,14 +14,52 @@ boolean
 true
 ```
 
-# addonRepositoryPath
+# addonManager.repositoryBranch
 
-指定插件仓库的路径（与 Addon Manager 无关）。
+指定插件管理器(Addon Manager)使用的git仓库分支
 
 ## type
 
 ```ts
 string
+```
+
+## default
+
+```jsonc
+""
+```
+
+# addonManager.repositoryPath
+
+指定插件管理器(Addon Manager)使用的git仓库路径
+
+## type
+
+```ts
+string
+```
+
+## default
+
+```jsonc
+""
+```
+
+# addonRepositoryPath
+
+指定插件仓库的路径（与 Addon Manager 无关）
+
+## type
+
+```ts
+string
+```
+
+## default
+
+```jsonc
+""
 ```
 
 # codeLens.enable
@@ -132,6 +170,22 @@ string
 "Replace"
 ```
 
+# completion.maxSuggestCount
+
+自动完成时最多分析的字段数量。当对象字段超过此上限时，需要更精确的输入才会显示补全。
+
+## type
+
+```ts
+integer
+```
+
+## default
+
+```jsonc
+100
+```
+
 # completion.postfix
 
 用于触发后缀建议的符号。
@@ -234,6 +288,7 @@ Array<string>
 * ``"ambiguity-1"``
 * ``"ambiguous-syntax"``
 * ``"args-after-dots"``
+* ``"assign-const-global"``
 * ``"assign-type-mismatch"``
 * ``"await-in-sync"``
 * ``"block-after-else"``
@@ -255,6 +310,7 @@ Array<string>
 * ``"duplicate-index"``
 * ``"duplicate-set-field"``
 * ``"empty-block"``
+* ``"env-is-global"``
 * ``"err-assign-as-eq"``
 * ``"err-c-long-comment"``
 * ``"err-comment-prefix"``
@@ -264,6 +320,7 @@ Array<string>
 * ``"err-nonstandard-symbol"``
 * ``"err-then-as-do"``
 * ``"exp-in-action"``
+* ``"global-close-attribute"``
 * ``"global-element"``
 * ``"global-in-nil-env"``
 * ``"incomplete-signature-doc"``
@@ -318,6 +375,7 @@ Array<string>
 * ``"missing-parameter"``
 * ``"missing-return"``
 * ``"missing-return-value"``
+* ``"multi-close"``
 * ``"name-style-check"``
 * ``"need-check-nil"``
 * ``"need-paren"``
@@ -347,6 +405,7 @@ Array<string>
 * ``"undefined-global"``
 * ``"unexpect-dots"``
 * ``"unexpect-efunc-name"``
+* ``"unexpect-gfunc-name"``
 * ``"unexpect-lfunc-name"``
 * ``"unexpect-symbol"``
 * ``"unicode-name"``
@@ -356,32 +415,18 @@ Array<string>
 * ``"unknown-operator"``
 * ``"unknown-symbol"``
 * ``"unreachable-code"``
+* ``"unsupport-named-vararg"``
 * ``"unsupport-symbol"``
 * ``"unused-function"``
 * ``"unused-label"``
 * ``"unused-local"``
 * ``"unused-vararg"``
+* ``"variable-not-declared"``
 
 ## default
 
 ```jsonc
 []
-```
-
-# diagnostics.disableScheme
-
-不诊断使用以下 scheme 的lua文件。
-
-## type
-
-```ts
-Array<string>
-```
-
-## default
-
-```jsonc
-["git"]
 ```
 
 # diagnostics.enable
@@ -398,6 +443,22 @@ boolean
 
 ```jsonc
 true
+```
+
+# diagnostics.enableScheme
+
+**Missing description!!**
+
+## type
+
+```ts
+Array<string>
+```
+
+## default
+
+```jsonc
+["file"]
 ```
 
 # diagnostics.globals
@@ -418,7 +479,7 @@ Array<string>
 
 # diagnostics.globalsRegex
 
-Find defined global variables using regex.
+已定义的全局变量符合的正则表达式。
 
 ## type
 
@@ -771,64 +832,64 @@ object<string, string>
     */
     "ambiguity-1": "Any",
     /*
-    Enable diagnostics for assignments in which the value's type does not match the type of the assigned variable.
+    值类型与赋值变量类型不匹配
     */
     "assign-type-mismatch": "Opened",
     /*
-    Enable diagnostics for calls of asynchronous functions within a synchronous function.
+    同步函数中异步函数调用
     */
     "await-in-sync": "None",
     /*
-    Enable diagnostics for casts of local variables where the target type does not match the defined type.
+    已显式定义变量类型与要定义的值的类型不匹配
     */
     "cast-local-type": "Opened",
     /*
-    Enable diagnostics for casts where the target type does not match the initial type.
+    变量被转换为与其初始类型不匹配的类型
     */
     "cast-type-mismatch": "Opened",
     "circle-doc-class": "Any",
     /*
-    Enable diagnostics for attempts to close a variable with a non-object.
+    尝试关闭非对象变量的诊断
     */
     "close-non-object": "Any",
     /*
-    Enable diagnostics for code placed after a break statement in a loop.
+    放在循环中break语句后面的代码
     */
     "code-after-break": "Opened",
     /*
-    Enable diagnostics for incorrectly styled lines.
+    启用对不正确样式行的诊断
     */
     "codestyle-check": "None",
     /*
-    Enable diagnostics for `for` loops which will never reach their max/limit because the loop is incrementing instead of decrementing.
+    for循环永远无法达到最大/极限值(在递减时递增)
     */
     "count-down-loop": "Any",
     /*
-    Enable diagnostics to highlight deprecated API.
+    变量已被标记为deprecated(过时)但仍在使用
     */
     "deprecated": "Any",
     /*
-    Enable diagnostics for files which are required by two different paths.
+    required的同一个文件使用了两个不同的名字
     */
     "different-requires": "Any",
     /*
-    Enable diagnostics for calls of functions annotated with `---@nodiscard` where the return values are ignored.
+    函数的返回值被忽略(函数被`@nodiscard`标记时)
     */
     "discard-returns": "Any",
     /*
-    Enable diagnostics to highlight a field annotation without a defining class annotation.
+    为不存在的类`@class`标记`@field`字段
     */
     "doc-field-no-class": "Any",
     /*
-    Enable diagnostics for a duplicated alias annotation name.
+    `@alias`字段的名字冲突
     */
     "duplicate-doc-alias": "Any",
     /*
-    Enable diagnostics for a duplicated field annotation name.
+    `@field`字段的名字冲突
     */
     "duplicate-doc-field": "Any",
     /*
-    Enable diagnostics for a duplicated param annotation name.
+    `@param`字段的名字冲突
     */
     "duplicate-doc-param": "Any",
     /*
@@ -836,7 +897,7 @@ object<string, string>
     */
     "duplicate-index": "Any",
     /*
-    Enable diagnostics for setting the same field in a class more than once.
+    在一个类中多次定义同一字段
     */
     "duplicate-set-field": "Opened",
     /*
@@ -844,7 +905,7 @@ object<string, string>
     */
     "empty-block": "Opened",
     /*
-    Enable diagnostics to warn about global elements.
+    启用诊断以警告全局元素。
     */
     "global-element": "None",
     /*
@@ -852,12 +913,12 @@ object<string, string>
     */
     "global-in-nil-env": "Any",
     /*
-    Incomplete @param or @return annotations for functions.
+    `@param`或`@return`的注释不完整
     */
     "incomplete-signature-doc": "None",
     "inject-field": "Opened",
     /*
-    Enable diagnostics for accesses to fields which are invisible.
+    使用不可见的值
     */
     "invisible": "Any",
     /*
@@ -866,31 +927,31 @@ object<string, string>
     "lowercase-global": "Any",
     "missing-fields": "Any",
     /*
-    Missing annotations for globals! Global functions must have a comment and annotations for all parameters and return values.
+    全局变量的注释缺失(全局函数必须为所有参数和返回值提供注释和注释)
     */
     "missing-global-doc": "None",
     /*
-    Missing annotations for exported locals! Exported local functions must have a comment and annotations for all parameters and return values.
+    导出的本地函数缺少注释(导出的本地函数必须有包括本身以及所有参数和返回值的注释)
     */
     "missing-local-export-doc": "None",
     /*
-    Enable diagnostics for function calls where the number of arguments is less than the number of annotated function parameters.
+    函数参数数少于注释函数参数数
     */
     "missing-parameter": "Any",
     /*
-    Enable diagnostics for functions with return annotations which have no return statement.
+    函数带有返回注释而无返回语句
     */
     "missing-return": "Any",
     /*
-    Enable diagnostics for return statements without values although the containing function declares returns.
+    函数无值返回但函数使用`@return`标记了返回值
     */
     "missing-return-value": "Any",
     /*
-    Enable diagnostics for name style.
+    变量的名称样式检查
     */
     "name-style-check": "None",
     /*
-    Enable diagnostics for variable usages if `nil` or an optional (potentially `nil`) value was assigned to the variable before.
+    变量之前被赋值为`nil`或可选值(可能为 `nil`)
     */
     "need-check-nil": "Opened",
     /*
@@ -902,15 +963,15 @@ object<string, string>
     */
     "newline-call": "Any",
     /*
-    Enable diagnostics for cases in which the type cannot be inferred.
+    变量的未知类型无法推断
     */
     "no-unknown": "None",
     /*
-    Enable diagnostics for calls to `coroutine.yield()` when it is not permitted.
+    不允许调用 `coroutine.yield()` 
     */
     "not-yieldable": "None",
     /*
-    Enable diagnostics for function calls where the type of a provided parameter does not match the type of the annotated function definition.
+    给定参数的类型与函数定义所要求的类型(`@param`)不匹配
     */
     "param-type-mismatch": "Opened",
     /*
@@ -922,11 +983,11 @@ object<string, string>
     */
     "redundant-parameter": "Any",
     /*
-    Enable diagnostics for return statements which are not needed because the function would exit on its own.
+    当放置一个不需要的返回值时触发(函数会自行退出)
     */
     "redundant-return": "Opened",
     /*
-    Enable diagnostics for return statements which return an extra value which is not specified by a return annotation.
+    返回`@return`注释未指定的额外值
     */
     "redundant-return-value": "Any",
     /*
@@ -934,11 +995,11 @@ object<string, string>
     */
     "redundant-value": "Any",
     /*
-    Enable diagnostics for return values whose type does not match the type declared in the corresponding return annotation.
+    返回值的类型与`@return`中声明的类型不匹配
     */
     "return-type-mismatch": "Opened",
     /*
-    Enable diagnostics for typos in strings.
+    启用字符串拼写检查的诊断。
     */
     "spell-check": "None",
     /*
@@ -946,19 +1007,19 @@ object<string, string>
     */
     "trailing-space": "Opened",
     /*
-    Enable diagnostics on multiple assignments if not all variables obtain a value (e.g., `local x,y = 1`).
+    多重赋值时没有赋值所有变量(如`local x,y = 1`)
     */
     "unbalanced-assignments": "Any",
     /*
-    Enable diagnostics for class annotations in which an undefined class is referenced.
+    在`@class`注解中引用未定义的类。
     */
     "undefined-doc-class": "Any",
     /*
-    Enable diagnostics for type annotations referencing an undefined type or alias.
+    在`@type`注解中引用未定义的类型或`@alias`
     */
     "undefined-doc-name": "Any",
     /*
-    Enable diagnostics for cases in which a parameter annotation is given without declaring the parameter in the function definition.
+    函数声明中`@param`引用了未定义的参数
     */
     "undefined-doc-param": "Any",
     /*
@@ -966,7 +1027,7 @@ object<string, string>
     */
     "undefined-env-child": "Any",
     /*
-    Enable diagnostics for cases in which an undefined field of a variable is read.
+    引用变量的未定义字段
     */
     "undefined-field": "Opened",
     /*
@@ -974,19 +1035,19 @@ object<string, string>
     */
     "undefined-global": "Any",
     /*
-    Enable diagnostics for casts of undefined variables.
+    使用`@cast`对未定义变量的强制转换
     */
     "unknown-cast-variable": "Any",
     /*
-    Enable diagnostics in cases in which an unknown diagnostics code is entered.
+    未知的诊断代码
     */
     "unknown-diag-code": "Any",
     /*
-    Enable diagnostics for unknown operators.
+    未知的运算符
     */
     "unknown-operator": "Any",
     /*
-    Enable diagnostics for unreachable code.
+    不可达的代码
     */
     "unreachable-code": "Opened",
     /*
@@ -1040,64 +1101,64 @@ object<string, string>
     */
     "ambiguity-1": "Warning",
     /*
-    Enable diagnostics for assignments in which the value's type does not match the type of the assigned variable.
+    值类型与赋值变量类型不匹配
     */
     "assign-type-mismatch": "Warning",
     /*
-    Enable diagnostics for calls of asynchronous functions within a synchronous function.
+    同步函数中异步函数调用
     */
     "await-in-sync": "Warning",
     /*
-    Enable diagnostics for casts of local variables where the target type does not match the defined type.
+    已显式定义变量类型与要定义的值的类型不匹配
     */
     "cast-local-type": "Warning",
     /*
-    Enable diagnostics for casts where the target type does not match the initial type.
+    变量被转换为与其初始类型不匹配的类型
     */
     "cast-type-mismatch": "Warning",
     "circle-doc-class": "Warning",
     /*
-    Enable diagnostics for attempts to close a variable with a non-object.
+    尝试关闭非对象变量的诊断
     */
     "close-non-object": "Warning",
     /*
-    Enable diagnostics for code placed after a break statement in a loop.
+    放在循环中break语句后面的代码
     */
     "code-after-break": "Hint",
     /*
-    Enable diagnostics for incorrectly styled lines.
+    启用对不正确样式行的诊断
     */
     "codestyle-check": "Warning",
     /*
-    Enable diagnostics for `for` loops which will never reach their max/limit because the loop is incrementing instead of decrementing.
+    for循环永远无法达到最大/极限值(在递减时递增)
     */
     "count-down-loop": "Warning",
     /*
-    Enable diagnostics to highlight deprecated API.
+    变量已被标记为deprecated(过时)但仍在使用
     */
     "deprecated": "Warning",
     /*
-    Enable diagnostics for files which are required by two different paths.
+    required的同一个文件使用了两个不同的名字
     */
     "different-requires": "Warning",
     /*
-    Enable diagnostics for calls of functions annotated with `---@nodiscard` where the return values are ignored.
+    函数的返回值被忽略(函数被`@nodiscard`标记时)
     */
     "discard-returns": "Warning",
     /*
-    Enable diagnostics to highlight a field annotation without a defining class annotation.
+    为不存在的类`@class`标记`@field`字段
     */
     "doc-field-no-class": "Warning",
     /*
-    Enable diagnostics for a duplicated alias annotation name.
+    `@alias`字段的名字冲突
     */
     "duplicate-doc-alias": "Warning",
     /*
-    Enable diagnostics for a duplicated field annotation name.
+    `@field`字段的名字冲突
     */
     "duplicate-doc-field": "Warning",
     /*
-    Enable diagnostics for a duplicated param annotation name.
+    `@param`字段的名字冲突
     */
     "duplicate-doc-param": "Warning",
     /*
@@ -1105,7 +1166,7 @@ object<string, string>
     */
     "duplicate-index": "Warning",
     /*
-    Enable diagnostics for setting the same field in a class more than once.
+    在一个类中多次定义同一字段
     */
     "duplicate-set-field": "Warning",
     /*
@@ -1113,7 +1174,7 @@ object<string, string>
     */
     "empty-block": "Hint",
     /*
-    Enable diagnostics to warn about global elements.
+    启用诊断以警告全局元素。
     */
     "global-element": "Warning",
     /*
@@ -1121,12 +1182,12 @@ object<string, string>
     */
     "global-in-nil-env": "Warning",
     /*
-    Incomplete @param or @return annotations for functions.
+    `@param`或`@return`的注释不完整
     */
     "incomplete-signature-doc": "Warning",
     "inject-field": "Warning",
     /*
-    Enable diagnostics for accesses to fields which are invisible.
+    使用不可见的值
     */
     "invisible": "Warning",
     /*
@@ -1135,31 +1196,31 @@ object<string, string>
     "lowercase-global": "Information",
     "missing-fields": "Warning",
     /*
-    Missing annotations for globals! Global functions must have a comment and annotations for all parameters and return values.
+    全局变量的注释缺失(全局函数必须为所有参数和返回值提供注释和注释)
     */
     "missing-global-doc": "Warning",
     /*
-    Missing annotations for exported locals! Exported local functions must have a comment and annotations for all parameters and return values.
+    导出的本地函数缺少注释(导出的本地函数必须有包括本身以及所有参数和返回值的注释)
     */
     "missing-local-export-doc": "Warning",
     /*
-    Enable diagnostics for function calls where the number of arguments is less than the number of annotated function parameters.
+    函数参数数少于注释函数参数数
     */
     "missing-parameter": "Warning",
     /*
-    Enable diagnostics for functions with return annotations which have no return statement.
+    函数带有返回注释而无返回语句
     */
     "missing-return": "Warning",
     /*
-    Enable diagnostics for return statements without values although the containing function declares returns.
+    函数无值返回但函数使用`@return`标记了返回值
     */
     "missing-return-value": "Warning",
     /*
-    Enable diagnostics for name style.
+    变量的名称样式检查
     */
     "name-style-check": "Warning",
     /*
-    Enable diagnostics for variable usages if `nil` or an optional (potentially `nil`) value was assigned to the variable before.
+    变量之前被赋值为`nil`或可选值(可能为 `nil`)
     */
     "need-check-nil": "Warning",
     /*
@@ -1171,15 +1232,15 @@ object<string, string>
     */
     "newline-call": "Warning",
     /*
-    Enable diagnostics for cases in which the type cannot be inferred.
+    变量的未知类型无法推断
     */
     "no-unknown": "Warning",
     /*
-    Enable diagnostics for calls to `coroutine.yield()` when it is not permitted.
+    不允许调用 `coroutine.yield()` 
     */
     "not-yieldable": "Warning",
     /*
-    Enable diagnostics for function calls where the type of a provided parameter does not match the type of the annotated function definition.
+    给定参数的类型与函数定义所要求的类型(`@param`)不匹配
     */
     "param-type-mismatch": "Warning",
     /*
@@ -1191,11 +1252,11 @@ object<string, string>
     */
     "redundant-parameter": "Warning",
     /*
-    Enable diagnostics for return statements which are not needed because the function would exit on its own.
+    当放置一个不需要的返回值时触发(函数会自行退出)
     */
     "redundant-return": "Hint",
     /*
-    Enable diagnostics for return statements which return an extra value which is not specified by a return annotation.
+    返回`@return`注释未指定的额外值
     */
     "redundant-return-value": "Warning",
     /*
@@ -1203,11 +1264,11 @@ object<string, string>
     */
     "redundant-value": "Warning",
     /*
-    Enable diagnostics for return values whose type does not match the type declared in the corresponding return annotation.
+    返回值的类型与`@return`中声明的类型不匹配
     */
     "return-type-mismatch": "Warning",
     /*
-    Enable diagnostics for typos in strings.
+    启用字符串拼写检查的诊断。
     */
     "spell-check": "Information",
     /*
@@ -1215,19 +1276,19 @@ object<string, string>
     */
     "trailing-space": "Hint",
     /*
-    Enable diagnostics on multiple assignments if not all variables obtain a value (e.g., `local x,y = 1`).
+    多重赋值时没有赋值所有变量(如`local x,y = 1`)
     */
     "unbalanced-assignments": "Warning",
     /*
-    Enable diagnostics for class annotations in which an undefined class is referenced.
+    在`@class`注解中引用未定义的类。
     */
     "undefined-doc-class": "Warning",
     /*
-    Enable diagnostics for type annotations referencing an undefined type or alias.
+    在`@type`注解中引用未定义的类型或`@alias`
     */
     "undefined-doc-name": "Warning",
     /*
-    Enable diagnostics for cases in which a parameter annotation is given without declaring the parameter in the function definition.
+    函数声明中`@param`引用了未定义的参数
     */
     "undefined-doc-param": "Warning",
     /*
@@ -1235,7 +1296,7 @@ object<string, string>
     */
     "undefined-env-child": "Information",
     /*
-    Enable diagnostics for cases in which an undefined field of a variable is read.
+    引用变量的未定义字段
     */
     "undefined-field": "Warning",
     /*
@@ -1243,19 +1304,19 @@ object<string, string>
     */
     "undefined-global": "Warning",
     /*
-    Enable diagnostics for casts of undefined variables.
+    使用`@cast`对未定义变量的强制转换
     */
     "unknown-cast-variable": "Warning",
     /*
-    Enable diagnostics in cases in which an unknown diagnostics code is entered.
+    未知的诊断代码
     */
     "unknown-diag-code": "Warning",
     /*
-    Enable diagnostics for unknown operators.
+    未知的运算符
     */
     "unknown-operator": "Warning",
     /*
-    Enable diagnostics for unreachable code.
+    不可达的代码
     */
     "unreachable-code": "Hint",
     /*
@@ -1395,6 +1456,43 @@ Array<string>
 []
 ```
 
+# doc.regengine
+
+用于匹配文档作用域名称的正则表达式引擎。
+
+## type
+
+```ts
+string
+```
+
+## enum
+
+* ``"glob"``: 默认轻量级模式语法。
+* ``"lua"``: 完整的 Lua 风格正则表达式。
+
+## default
+
+```jsonc
+"glob"
+```
+
+# docScriptPath
+
+自定义 Lua 脚本路径，覆盖默认文档生成行为。
+
+## type
+
+```ts
+string
+```
+
+## default
+
+```jsonc
+""
+```
+
 # format.defaultConfig
 
 默认的格式化配置，优先级低于工作区内的 `.editorconfig` 文件。
@@ -1465,6 +1563,22 @@ boolean
 
 ```jsonc
 true
+```
+
+# hint.awaitPropagate
+
+启用 `await` 的传播, 当一个函数调用了一个`---@async`标记的函数时，会自动标记为`---@async`。
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+false
 ```
 
 # hint.enable
@@ -1621,7 +1735,7 @@ integer
 ## default
 
 ```jsonc
-50
+10
 ```
 
 # hover.viewNumber
@@ -1672,6 +1786,38 @@ integer
 1000
 ```
 
+# language.completeAnnotation
+
+(仅VSCode) 在注解后换行时自动插入 "---@ "。
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+true
+```
+
+# language.fixIndent
+
+(仅VSCode) 修复错误的自动缩进，例如在包含单词 "function" 的字符串中换行时出现的错误缩进。
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+true
+```
+
 # misc.executablePath
 
 VSCode中指定可执行文件路径。
@@ -1706,7 +1852,9 @@ Array<string>
 
 # nameStyle.config
 
-设定命名风格检查的配置
+设定命名风格检查的配置。
+请查阅[格式化文档](https://github.com/CppCXY/EmmyLuaCodeStyle/tree/master/docs)了解用法。
+
 
 ## type
 
@@ -1838,6 +1986,7 @@ Array<string>
 * ``"!"``
 * ``"!="``
 * ``"continue"``
+* ``"|lambda|"``
 
 ## default
 
@@ -1888,29 +2037,29 @@ false
 ## type
 
 ```ts
-string
+string | array
 ```
 
 ## default
 
 ```jsonc
-""
+null
 ```
 
 # runtime.pluginArgs
 
-Additional arguments for the plugin.
+插件的额外参数。
 
 ## type
 
 ```ts
-Array<string>
+array | object
 ```
 
 ## default
 
 ```jsonc
-[]
+null
 ```
 
 # runtime.special
@@ -1968,6 +2117,7 @@ string
 * ``"Lua 5.2"``
 * ``"Lua 5.3"``
 * ``"Lua 5.4"``
+* ``"Lua 5.5"``
 * ``"LuaJIT"``
 
 ## default
@@ -2088,6 +2238,74 @@ boolean
 true
 ```
 
+# type.checkTableShape
+
+对表的形状进行严格检查。
+
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+false
+```
+
+# type.inferParamType
+
+未注释参数类型时，参数类型由函数传入参数推断。
+
+如果设置为 "false"，则在未注释时，参数类型为 "any"。
+
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+false
+```
+
+# type.inferTableSize
+
+类型推断期间分析的表字段的最大数量。
+
+## type
+
+```ts
+integer
+```
+
+## default
+
+```jsonc
+10
+```
+
+# type.maxUnionVariants
+
+**Missing description!!**
+
+## type
+
+```ts
+integer
+```
+
+## default
+
+```jsonc
+0
+```
+
 # type.weakNilCheck
 
 对联合类型进行类型检查时，忽略其中的 `nil`。
@@ -2128,7 +2346,7 @@ false
 
 # typeFormat.config
 
-Configures the formatting behavior while typing Lua code.
+配置输入Lua代码时的格式化行为
 
 ## type
 
@@ -2141,15 +2359,15 @@ object<string, string>
 ```jsonc
 {
     /*
-    Controls if `end` is automatically completed at suitable positions.
+    是否在合适的位置自动完成 `end`
     */
     "auto_complete_end": "true",
     /*
-    Controls if a separator is automatically appended at the end of a table declaration.
+    是否在table末尾自动添加分隔符
     */
     "auto_complete_table_sep": "true",
     /*
-    Controls if a line is formatted at all.
+    是否对某一行进行格式化
     */
     "format_line": "true"
 }
@@ -2202,20 +2420,29 @@ true
 ## type
 
 ```ts
-string
+string | boolean
 ```
-
-## enum
-
-* ``"Ask"``
-* ``"Apply"``
-* ``"ApplyInMemory"``
-* ``"Disable"``
 
 ## default
 
 ```jsonc
-"Ask"
+null
+```
+
+# workspace.dofileRoots
+
+In addition to the current workspace, which directories `dofile` will treat as a possible root. The files in these directories will be loaded immediately.
+
+## type
+
+```ts
+Array<string>
+```
+
+## default
+
+```jsonc
+[]
 ```
 
 # workspace.ignoreDir

--- a/doc/zh-tw/config.md
+++ b/doc/zh-tw/config.md
@@ -1,6 +1,6 @@
 # addonManager.enable
 
-Whether the addon manager is enabled or not.
+是否啟用延伸模組的附加插件管理器（Addon Manager）。
 
 ## type
 
@@ -14,9 +14,9 @@ boolean
 true
 ```
 
-# addonRepositoryPath
+# addonManager.repositoryBranch
 
-Specifies the addon repository path (not related to the addon manager).
+指定插件管理器（Addon Manager）使用的git branch。
 
 ## type
 
@@ -24,9 +24,47 @@ Specifies the addon repository path (not related to the addon manager).
 string
 ```
 
+## default
+
+```jsonc
+""
+```
+
+# addonManager.repositoryPath
+
+指定插件管理器（Addon Manager）使用的git path。
+
+## type
+
+```ts
+string
+```
+
+## default
+
+```jsonc
+""
+```
+
+# addonRepositoryPath
+
+指定獨立的插件倉庫路徑（與插件管理器無關）。
+
+## type
+
+```ts
+string
+```
+
+## default
+
+```jsonc
+""
+```
+
 # codeLens.enable
 
-Enable code lens.
+啟用CodeLens。
 
 ## type
 
@@ -42,7 +80,7 @@ false
 
 # completion.autoRequire
 
-輸入內容看起來是個檔名時，自動 `require` 此檔案。
+輸入內容看起來像檔名時，自動 `require` 此檔案。
 
 ## type
 
@@ -130,6 +168,22 @@ string
 
 ```jsonc
 "Replace"
+```
+
+# completion.maxSuggestCount
+
+自動完成時最多分析的欄位數量。若物件欄位超過此上限，必須提供更精確的輸入才會顯示建議。
+
+## type
+
+```ts
+integer
+```
+
+## default
+
+```jsonc
+100
 ```
 
 # completion.postfix
@@ -234,6 +288,7 @@ Array<string>
 * ``"ambiguity-1"``
 * ``"ambiguous-syntax"``
 * ``"args-after-dots"``
+* ``"assign-const-global"``
 * ``"assign-type-mismatch"``
 * ``"await-in-sync"``
 * ``"block-after-else"``
@@ -255,6 +310,7 @@ Array<string>
 * ``"duplicate-index"``
 * ``"duplicate-set-field"``
 * ``"empty-block"``
+* ``"env-is-global"``
 * ``"err-assign-as-eq"``
 * ``"err-c-long-comment"``
 * ``"err-comment-prefix"``
@@ -264,6 +320,7 @@ Array<string>
 * ``"err-nonstandard-symbol"``
 * ``"err-then-as-do"``
 * ``"exp-in-action"``
+* ``"global-close-attribute"``
 * ``"global-element"``
 * ``"global-in-nil-env"``
 * ``"incomplete-signature-doc"``
@@ -318,6 +375,7 @@ Array<string>
 * ``"missing-parameter"``
 * ``"missing-return"``
 * ``"missing-return-value"``
+* ``"multi-close"``
 * ``"name-style-check"``
 * ``"need-check-nil"``
 * ``"need-paren"``
@@ -347,6 +405,7 @@ Array<string>
 * ``"undefined-global"``
 * ``"unexpect-dots"``
 * ``"unexpect-efunc-name"``
+* ``"unexpect-gfunc-name"``
 * ``"unexpect-lfunc-name"``
 * ``"unexpect-symbol"``
 * ``"unicode-name"``
@@ -356,32 +415,18 @@ Array<string>
 * ``"unknown-operator"``
 * ``"unknown-symbol"``
 * ``"unreachable-code"``
+* ``"unsupport-named-vararg"``
 * ``"unsupport-symbol"``
 * ``"unused-function"``
 * ``"unused-label"``
 * ``"unused-local"``
 * ``"unused-vararg"``
+* ``"variable-not-declared"``
 
 ## default
 
 ```jsonc
 []
-```
-
-# diagnostics.disableScheme
-
-不診斷使用以下 scheme 的lua檔案。
-
-## type
-
-```ts
-Array<string>
-```
-
-## default
-
-```jsonc
-["git"]
 ```
 
 # diagnostics.enable
@@ -398,6 +443,22 @@ boolean
 
 ```jsonc
 true
+```
+
+# diagnostics.enableScheme
+
+**Missing description!!**
+
+## type
+
+```ts
+Array<string>
+```
+
+## default
+
+```jsonc
+["file"]
 ```
 
 # diagnostics.globals
@@ -418,7 +479,7 @@ Array<string>
 
 # diagnostics.globalsRegex
 
-Find defined global variables using regex.
+使用正規表示式尋找全域變數。
 
 ## type
 
@@ -434,7 +495,7 @@ Array<string>
 
 # diagnostics.groupFileStatus
 
-批量修改一個組中的檔案狀態。
+批次修改一個組中的檔案狀態。
 
 * Opened:  只診斷打開的檔案
 * Any:     診斷所有檔案
@@ -567,7 +628,7 @@ object<string, string>
 
 # diagnostics.groupSeverity
 
-批量修改一個組中的診斷等級。
+批次修改一個組中的診斷等級。
 設定為 `Fallback` 意味著組中的診斷由 `diagnostics.severity` 單獨設定。
 其他設定將覆蓋單獨設定，但是不會覆蓋以 `!` 結尾的設定。
 
@@ -771,64 +832,64 @@ object<string, string>
     */
     "ambiguity-1": "Any",
     /*
-    Enable diagnostics for assignments in which the value's type does not match the type of the assigned variable.
+    賦值類型與變數類型不符合
     */
     "assign-type-mismatch": "Opened",
     /*
-    Enable diagnostics for calls of asynchronous functions within a synchronous function.
+    同步函式中呼叫非同步函式
     */
     "await-in-sync": "None",
     /*
-    Enable diagnostics for casts of local variables where the target type does not match the defined type.
+    已顯式定義變數類型不符合要定義的值的類型
     */
     "cast-local-type": "Opened",
     /*
-    Enable diagnostics for casts where the target type does not match the initial type.
+    變數被轉換為不符合其初始類型的類型
     */
     "cast-type-mismatch": "Opened",
     "circle-doc-class": "Any",
     /*
-    Enable diagnostics for attempts to close a variable with a non-object.
+    嘗試關閉非物件變數
     */
     "close-non-object": "Any",
     /*
-    Enable diagnostics for code placed after a break statement in a loop.
+    迴圈內break陳述式後的程式碼
     */
     "code-after-break": "Opened",
     /*
-    Enable diagnostics for incorrectly styled lines.
+    行的格式不正確
     */
     "codestyle-check": "None",
     /*
-    Enable diagnostics for `for` loops which will never reach their max/limit because the loop is incrementing instead of decrementing.
+    因為 `for` 迴圈是遞增而不是遞減，所以不會到達上限/極限
     */
     "count-down-loop": "Any",
     /*
-    Enable diagnostics to highlight deprecated API.
+    API已標記deprecated（棄用）但仍在使用
     */
     "deprecated": "Any",
     /*
-    Enable diagnostics for files which are required by two different paths.
+    required的同一個檔案使用了兩個不同的名字
     */
     "different-requires": "Any",
     /*
-    Enable diagnostics for calls of functions annotated with `---@nodiscard` where the return values are ignored.
+    忽略了標註為 `@nodiscard` 的函式的回傳值
     */
     "discard-returns": "Any",
     /*
-    Enable diagnostics to highlight a field annotation without a defining class annotation.
+    向沒有標註 `@class` 的類別標註 `@field` 欄位
     */
     "doc-field-no-class": "Any",
     /*
-    Enable diagnostics for a duplicated alias annotation name.
+    `@alias` 標註名字衝突
     */
     "duplicate-doc-alias": "Any",
     /*
-    Enable diagnostics for a duplicated field annotation name.
+    `@field` 標註名字衝突
     */
     "duplicate-doc-field": "Any",
     /*
-    Enable diagnostics for a duplicated param annotation name.
+    `@param` 標註名字衝突
     */
     "duplicate-doc-param": "Any",
     /*
@@ -836,7 +897,7 @@ object<string, string>
     */
     "duplicate-index": "Any",
     /*
-    Enable diagnostics for setting the same field in a class more than once.
+    在類別中多次定義相同的欄位
     */
     "duplicate-set-field": "Opened",
     /*
@@ -844,7 +905,7 @@ object<string, string>
     */
     "empty-block": "Opened",
     /*
-    Enable diagnostics to warn about global elements.
+    對全域元素的警告
     */
     "global-element": "None",
     /*
@@ -852,12 +913,12 @@ object<string, string>
     */
     "global-in-nil-env": "Any",
     /*
-    Incomplete @param or @return annotations for functions.
+    `@param` 或 `@return` 不完整
     */
     "incomplete-signature-doc": "None",
     "inject-field": "Opened",
     /*
-    Enable diagnostics for accesses to fields which are invisible.
+    嘗試存取不可見的欄位
     */
     "invisible": "Any",
     /*
@@ -866,31 +927,31 @@ object<string, string>
     "lowercase-global": "Any",
     "missing-fields": "Any",
     /*
-    Missing annotations for globals! Global functions must have a comment and annotations for all parameters and return values.
+    全域變數缺少標註（全域函式必須為所有參數和回傳值提供標註）
     */
     "missing-global-doc": "None",
     /*
-    Missing annotations for exported locals! Exported local functions must have a comment and annotations for all parameters and return values.
+    匯出的區域函式缺少標註（匯出的區域函式、所有的參數和回傳值都必須有標註）
     */
     "missing-local-export-doc": "None",
     /*
-    Enable diagnostics for function calls where the number of arguments is less than the number of annotated function parameters.
+    函式呼叫的引數數量比函式標註的參數數量少
     */
     "missing-parameter": "Any",
     /*
-    Enable diagnostics for functions with return annotations which have no return statement.
+    函式有 `@return` 標註卻沒有 `return` 陳述式
     */
     "missing-return": "Any",
     /*
-    Enable diagnostics for return statements without values although the containing function declares returns.
+    函式沒有回傳值，但使用了 `@return` 標註了回傳值
     */
     "missing-return-value": "Any",
     /*
-    Enable diagnostics for name style.
+    變數命名風格檢查
     */
     "name-style-check": "None",
     /*
-    Enable diagnostics for variable usages if `nil` or an optional (potentially `nil`) value was assigned to the variable before.
+    變數曾被賦值為 `nil` 或可選值（可能是 `nil` ）
     */
     "need-check-nil": "Opened",
     /*
@@ -902,15 +963,15 @@ object<string, string>
     */
     "newline-call": "Any",
     /*
-    Enable diagnostics for cases in which the type cannot be inferred.
+    無法推斷變數的未知類型
     */
     "no-unknown": "None",
     /*
-    Enable diagnostics for calls to `coroutine.yield()` when it is not permitted.
+    不允許呼叫 `coroutine.yield()`
     */
     "not-yieldable": "None",
     /*
-    Enable diagnostics for function calls where the type of a provided parameter does not match the type of the annotated function definition.
+    給定參數的類型不符合函式定義所要求的類型（ `@param` ）
     */
     "param-type-mismatch": "Opened",
     /*
@@ -922,11 +983,11 @@ object<string, string>
     */
     "redundant-parameter": "Any",
     /*
-    Enable diagnostics for return statements which are not needed because the function would exit on its own.
+    放了一個不需要的 `return` 陳述式，因為函式會自行退出
     */
     "redundant-return": "Opened",
     /*
-    Enable diagnostics for return statements which return an extra value which is not specified by a return annotation.
+    回傳了 `@return` 標註未指定的額外值
     */
     "redundant-return-value": "Any",
     /*
@@ -934,11 +995,11 @@ object<string, string>
     */
     "redundant-value": "Any",
     /*
-    Enable diagnostics for return values whose type does not match the type declared in the corresponding return annotation.
+    回傳值的類型不符合 `@return` 中宣告的類型
     */
     "return-type-mismatch": "Opened",
     /*
-    Enable diagnostics for typos in strings.
+    字串拼寫檢查
     */
     "spell-check": "None",
     /*
@@ -946,19 +1007,19 @@ object<string, string>
     */
     "trailing-space": "Opened",
     /*
-    Enable diagnostics on multiple assignments if not all variables obtain a value (e.g., `local x,y = 1`).
+    多重賦值時沒有賦值所有變數（如 `local x,y = 1` ）
     */
     "unbalanced-assignments": "Any",
     /*
-    Enable diagnostics for class annotations in which an undefined class is referenced.
+    在 `@class` 標註中引用未定義的類別。
     */
     "undefined-doc-class": "Any",
     /*
-    Enable diagnostics for type annotations referencing an undefined type or alias.
+    在 `@type` 標註中引用未定義的類型或 `@alias`
     */
     "undefined-doc-name": "Any",
     /*
-    Enable diagnostics for cases in which a parameter annotation is given without declaring the parameter in the function definition.
+    在 `@param` 標註中引用函式定義未宣告的參數
     */
     "undefined-doc-param": "Any",
     /*
@@ -966,7 +1027,7 @@ object<string, string>
     */
     "undefined-env-child": "Any",
     /*
-    Enable diagnostics for cases in which an undefined field of a variable is read.
+    讀取變數中為定義的欄位
     */
     "undefined-field": "Opened",
     /*
@@ -974,19 +1035,19 @@ object<string, string>
     */
     "undefined-global": "Any",
     /*
-    Enable diagnostics for casts of undefined variables.
+    使用 `@cast` 對未定義的變數進行強制轉換
     */
     "unknown-cast-variable": "Any",
     /*
-    Enable diagnostics in cases in which an unknown diagnostics code is entered.
+    輸入了未知的診斷
     */
     "unknown-diag-code": "Any",
     /*
-    Enable diagnostics for unknown operators.
+    未知的運算子
     */
     "unknown-operator": "Any",
     /*
-    Enable diagnostics for unreachable code.
+    無法到達的程式碼
     */
     "unreachable-code": "Opened",
     /*
@@ -1040,64 +1101,64 @@ object<string, string>
     */
     "ambiguity-1": "Warning",
     /*
-    Enable diagnostics for assignments in which the value's type does not match the type of the assigned variable.
+    賦值類型與變數類型不符合
     */
     "assign-type-mismatch": "Warning",
     /*
-    Enable diagnostics for calls of asynchronous functions within a synchronous function.
+    同步函式中呼叫非同步函式
     */
     "await-in-sync": "Warning",
     /*
-    Enable diagnostics for casts of local variables where the target type does not match the defined type.
+    已顯式定義變數類型不符合要定義的值的類型
     */
     "cast-local-type": "Warning",
     /*
-    Enable diagnostics for casts where the target type does not match the initial type.
+    變數被轉換為不符合其初始類型的類型
     */
     "cast-type-mismatch": "Warning",
     "circle-doc-class": "Warning",
     /*
-    Enable diagnostics for attempts to close a variable with a non-object.
+    嘗試關閉非物件變數
     */
     "close-non-object": "Warning",
     /*
-    Enable diagnostics for code placed after a break statement in a loop.
+    迴圈內break陳述式後的程式碼
     */
     "code-after-break": "Hint",
     /*
-    Enable diagnostics for incorrectly styled lines.
+    行的格式不正確
     */
     "codestyle-check": "Warning",
     /*
-    Enable diagnostics for `for` loops which will never reach their max/limit because the loop is incrementing instead of decrementing.
+    因為 `for` 迴圈是遞增而不是遞減，所以不會到達上限/極限
     */
     "count-down-loop": "Warning",
     /*
-    Enable diagnostics to highlight deprecated API.
+    API已標記deprecated（棄用）但仍在使用
     */
     "deprecated": "Warning",
     /*
-    Enable diagnostics for files which are required by two different paths.
+    required的同一個檔案使用了兩個不同的名字
     */
     "different-requires": "Warning",
     /*
-    Enable diagnostics for calls of functions annotated with `---@nodiscard` where the return values are ignored.
+    忽略了標註為 `@nodiscard` 的函式的回傳值
     */
     "discard-returns": "Warning",
     /*
-    Enable diagnostics to highlight a field annotation without a defining class annotation.
+    向沒有標註 `@class` 的類別標註 `@field` 欄位
     */
     "doc-field-no-class": "Warning",
     /*
-    Enable diagnostics for a duplicated alias annotation name.
+    `@alias` 標註名字衝突
     */
     "duplicate-doc-alias": "Warning",
     /*
-    Enable diagnostics for a duplicated field annotation name.
+    `@field` 標註名字衝突
     */
     "duplicate-doc-field": "Warning",
     /*
-    Enable diagnostics for a duplicated param annotation name.
+    `@param` 標註名字衝突
     */
     "duplicate-doc-param": "Warning",
     /*
@@ -1105,7 +1166,7 @@ object<string, string>
     */
     "duplicate-index": "Warning",
     /*
-    Enable diagnostics for setting the same field in a class more than once.
+    在類別中多次定義相同的欄位
     */
     "duplicate-set-field": "Warning",
     /*
@@ -1113,7 +1174,7 @@ object<string, string>
     */
     "empty-block": "Hint",
     /*
-    Enable diagnostics to warn about global elements.
+    對全域元素的警告
     */
     "global-element": "Warning",
     /*
@@ -1121,12 +1182,12 @@ object<string, string>
     */
     "global-in-nil-env": "Warning",
     /*
-    Incomplete @param or @return annotations for functions.
+    `@param` 或 `@return` 不完整
     */
     "incomplete-signature-doc": "Warning",
     "inject-field": "Warning",
     /*
-    Enable diagnostics for accesses to fields which are invisible.
+    嘗試存取不可見的欄位
     */
     "invisible": "Warning",
     /*
@@ -1135,31 +1196,31 @@ object<string, string>
     "lowercase-global": "Information",
     "missing-fields": "Warning",
     /*
-    Missing annotations for globals! Global functions must have a comment and annotations for all parameters and return values.
+    全域變數缺少標註（全域函式必須為所有參數和回傳值提供標註）
     */
     "missing-global-doc": "Warning",
     /*
-    Missing annotations for exported locals! Exported local functions must have a comment and annotations for all parameters and return values.
+    匯出的區域函式缺少標註（匯出的區域函式、所有的參數和回傳值都必須有標註）
     */
     "missing-local-export-doc": "Warning",
     /*
-    Enable diagnostics for function calls where the number of arguments is less than the number of annotated function parameters.
+    函式呼叫的引數數量比函式標註的參數數量少
     */
     "missing-parameter": "Warning",
     /*
-    Enable diagnostics for functions with return annotations which have no return statement.
+    函式有 `@return` 標註卻沒有 `return` 陳述式
     */
     "missing-return": "Warning",
     /*
-    Enable diagnostics for return statements without values although the containing function declares returns.
+    函式沒有回傳值，但使用了 `@return` 標註了回傳值
     */
     "missing-return-value": "Warning",
     /*
-    Enable diagnostics for name style.
+    變數命名風格檢查
     */
     "name-style-check": "Warning",
     /*
-    Enable diagnostics for variable usages if `nil` or an optional (potentially `nil`) value was assigned to the variable before.
+    變數曾被賦值為 `nil` 或可選值（可能是 `nil` ）
     */
     "need-check-nil": "Warning",
     /*
@@ -1171,15 +1232,15 @@ object<string, string>
     */
     "newline-call": "Warning",
     /*
-    Enable diagnostics for cases in which the type cannot be inferred.
+    無法推斷變數的未知類型
     */
     "no-unknown": "Warning",
     /*
-    Enable diagnostics for calls to `coroutine.yield()` when it is not permitted.
+    不允許呼叫 `coroutine.yield()`
     */
     "not-yieldable": "Warning",
     /*
-    Enable diagnostics for function calls where the type of a provided parameter does not match the type of the annotated function definition.
+    給定參數的類型不符合函式定義所要求的類型（ `@param` ）
     */
     "param-type-mismatch": "Warning",
     /*
@@ -1191,11 +1252,11 @@ object<string, string>
     */
     "redundant-parameter": "Warning",
     /*
-    Enable diagnostics for return statements which are not needed because the function would exit on its own.
+    放了一個不需要的 `return` 陳述式，因為函式會自行退出
     */
     "redundant-return": "Hint",
     /*
-    Enable diagnostics for return statements which return an extra value which is not specified by a return annotation.
+    回傳了 `@return` 標註未指定的額外值
     */
     "redundant-return-value": "Warning",
     /*
@@ -1203,11 +1264,11 @@ object<string, string>
     */
     "redundant-value": "Warning",
     /*
-    Enable diagnostics for return values whose type does not match the type declared in the corresponding return annotation.
+    回傳值的類型不符合 `@return` 中宣告的類型
     */
     "return-type-mismatch": "Warning",
     /*
-    Enable diagnostics for typos in strings.
+    字串拼寫檢查
     */
     "spell-check": "Information",
     /*
@@ -1215,19 +1276,19 @@ object<string, string>
     */
     "trailing-space": "Hint",
     /*
-    Enable diagnostics on multiple assignments if not all variables obtain a value (e.g., `local x,y = 1`).
+    多重賦值時沒有賦值所有變數（如 `local x,y = 1` ）
     */
     "unbalanced-assignments": "Warning",
     /*
-    Enable diagnostics for class annotations in which an undefined class is referenced.
+    在 `@class` 標註中引用未定義的類別。
     */
     "undefined-doc-class": "Warning",
     /*
-    Enable diagnostics for type annotations referencing an undefined type or alias.
+    在 `@type` 標註中引用未定義的類型或 `@alias`
     */
     "undefined-doc-name": "Warning",
     /*
-    Enable diagnostics for cases in which a parameter annotation is given without declaring the parameter in the function definition.
+    在 `@param` 標註中引用函式定義未宣告的參數
     */
     "undefined-doc-param": "Warning",
     /*
@@ -1235,7 +1296,7 @@ object<string, string>
     */
     "undefined-env-child": "Information",
     /*
-    Enable diagnostics for cases in which an undefined field of a variable is read.
+    讀取變數中為定義的欄位
     */
     "undefined-field": "Warning",
     /*
@@ -1243,19 +1304,19 @@ object<string, string>
     */
     "undefined-global": "Warning",
     /*
-    Enable diagnostics for casts of undefined variables.
+    使用 `@cast` 對未定義的變數進行強制轉換
     */
     "unknown-cast-variable": "Warning",
     /*
-    Enable diagnostics in cases in which an unknown diagnostics code is entered.
+    輸入了未知的診斷
     */
     "unknown-diag-code": "Warning",
     /*
-    Enable diagnostics for unknown operators.
+    未知的運算子
     */
     "unknown-operator": "Warning",
     /*
-    Enable diagnostics for unreachable code.
+    無法到達的程式碼
     */
     "unreachable-code": "Hint",
     /*
@@ -1279,7 +1340,7 @@ object<string, string>
 
 # diagnostics.unusedLocalExclude
 
-Do not diagnose `unused-local` when the variable name matches the following pattern.
+如果變數名符合以下規則，則不對其進行 `unused-local` 診斷。
 
 ## type
 
@@ -1311,7 +1372,7 @@ integer
 
 # diagnostics.workspaceEvent
 
-Set the time to trigger workspace diagnostics.
+設定觸發工作區診斷的時機。
 
 ## type
 
@@ -1321,9 +1382,9 @@ string
 
 ## enum
 
-* ``"OnChange"``: Trigger workspace diagnostics when the file is changed.
-* ``"OnSave"``: Trigger workspace diagnostics when the file is saved.
-* ``"None"``: Disable workspace diagnostics.
+* ``"OnChange"``: 當檔案發生變化時觸發工作區診斷。
+* ``"OnSave"``: 當儲存檔案時觸發工作區診斷。
+* ``"None"``: 停用工作區診斷。
 
 ## default
 
@@ -1349,7 +1410,7 @@ integer
 
 # doc.packageName
 
-Treat specific field names as package, e.g. `m_*` means `XXX.m_id` and `XXX.m_type` are package, witch can only be accessed in the file where the definition is located.
+將特定名稱的欄位視為package，例如 `m_*` 代表 `XXX.m_id` 和 `XXX.m_type` 只能在定義所在的檔案內存取
 
 ## type
 
@@ -1365,7 +1426,7 @@ Array<string>
 
 # doc.privateName
 
-Treat specific field names as private, e.g. `m_*` means `XXX.m_id` and `XXX.m_type` are private, witch can only be accessed in the class where the definition is located.
+將特定名稱的欄位視為private，例如 `m_*` 代表 `XXX.m_id` 和 `XXX.m_type` 會是私有層級，只能在定義所在的類別內存取
 
 ## type
 
@@ -1381,7 +1442,7 @@ Array<string>
 
 # doc.protectedName
 
-Treat specific field names as protected, e.g. `m_*` means `XXX.m_id` and `XXX.m_type` are protected, witch can only be accessed in the class where the definition is located and its subclasses.
+將特定名稱的欄位視為protected，例如 `m_*` 代表 `XXX.m_id` 和 `XXX.m_type` 會是保護層級，只能在定義所在的類別和其子類別內存取
 
 ## type
 
@@ -1393,6 +1454,43 @@ Array<string>
 
 ```jsonc
 []
+```
+
+# doc.regengine
+
+用於匹配文件作用域名稱的正則表達式引擎。
+
+## type
+
+```ts
+string
+```
+
+## enum
+
+* ``"glob"``: 預設的輕量模式語法。
+* ``"lua"``: 完整的 Lua 風格正則表達式。
+
+## default
+
+```jsonc
+"glob"
+```
+
+# docScriptPath
+
+用於匹配文件作用域名稱的正則表達式引擎。
+
+## type
+
+```ts
+string
+```
+
+## default
+
+```jsonc
+""
 ```
 
 # format.defaultConfig
@@ -1453,7 +1551,7 @@ string
 
 # hint.await
 
-如果呼叫的函數被標記為了 `---@async`，則在呼叫處提示 `await`。
+如果呼叫的函式被標記為了 `---@async`，則在呼叫處提示 `await`。
 
 ## type
 
@@ -1465,6 +1563,22 @@ boolean
 
 ```jsonc
 true
+```
+
+# hint.awaitPropagate
+
+啟用 `await` 的傳播，當一個函式呼叫了一個 `---@async` 標記的函式時，會自動標記為 `---@async`。
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+false
 ```
 
 # hint.enable
@@ -1593,7 +1707,7 @@ integer
 
 # hover.expandAlias
 
-是否展開別名。例如 `---@alias myType boolean|number` 展開後顯示為 `boolean|number`，否則顯示為 `myType'。
+是否展開別名。例如 `---@alias myType boolean|number` 展開後顯示為 `boolean|number`，否則顯示為 `myType`'。
 
 
 ## type
@@ -1621,7 +1735,7 @@ integer
 ## default
 
 ```jsonc
-50
+10
 ```
 
 # hover.viewNumber
@@ -1672,9 +1786,41 @@ integer
 1000
 ```
 
+# language.completeAnnotation
+
+（僅限VSCode）在註解後換行時自動插入 "---@ "。
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+true
+```
+
+# language.fixIndent
+
+（僅限VSCode）修復自動縮排錯誤，例如在有包含 "function" 的字串中換行時出現的錯誤縮排。
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+true
+```
+
 # misc.executablePath
 
-Specify the executable path in VSCode.
+指定VSCode內的可執行文件
 
 ## type
 
@@ -1690,7 +1836,7 @@ string
 
 # misc.parameters
 
-VSCode中啟動語言伺服時的[命令列參數](https://luals.github.io/wiki/usage#arguments)。
+VSCode內啟動語言伺服時的[命令列參數](https://luals.github.io/wiki/usage#arguments)。
 
 ## type
 
@@ -1706,7 +1852,9 @@ Array<string>
 
 # nameStyle.config
 
-Set name style config
+設定檢查命名風格的組態。
+閱讀 [formatter docs](https://github.com/CppCXY/EmmyLuaCodeStyle/tree/master/docs) 了解用法。
+
 
 ## type
 
@@ -1838,6 +1986,7 @@ Array<string>
 * ``"!"``
 * ``"!="``
 * ``"continue"``
+* ``"|lambda|"``
 
 ## default
 
@@ -1848,7 +1997,7 @@ Array<string>
 # runtime.path
 
 當使用 `require` 時，如何根據輸入的名字來尋找檔案。
-此選項設定為 `?/init.lua` 意味著當你輸入 `require 'myfile'` 時，會從已載入的檔案中搜尋 `{workspace}/myfile/init.lua`。
+此選項設定為 `?/init.lua` 時，代表當你輸入 `require 'myfile'` 時，會從已載入的檔案中搜尋 `{workspace}/myfile/init.lua`。
 當 `runtime.pathStrict` 設定為 `false` 時，還會嘗試搜尋 `${workspace}/**/myfile/init.lua`。
 如果你想要載入工作區以外的檔案，你需要先設定 `Lua.workspace.library`。
 
@@ -1867,7 +2016,7 @@ Array<string>
 
 # runtime.pathStrict
 
-啟用後 `runtime.path` 將只搜尋第一層目錄，見 `runtime.path` 的説明。
+啟用後 `runtime.path` 將只搜尋第一層目錄，見 `runtime.path` 的說明。
 
 ## type
 
@@ -1888,29 +2037,29 @@ false
 ## type
 
 ```ts
-string
+string | array
 ```
 
 ## default
 
 ```jsonc
-""
+null
 ```
 
 # runtime.pluginArgs
 
-Additional arguments for the plugin.
+延伸模組的額外引數。
 
 ## type
 
 ```ts
-Array<string>
+array | object
 ```
 
 ## default
 
 ```jsonc
-[]
+null
 ```
 
 # runtime.special
@@ -1968,6 +2117,7 @@ string
 * ``"Lua 5.2"``
 * ``"Lua 5.3"``
 * ``"Lua 5.4"``
+* ``"Lua 5.5"``
 * ``"LuaJIT"``
 
 ## default
@@ -2088,11 +2238,79 @@ boolean
 true
 ```
 
+# type.checkTableShape
+
+對表的形狀進行嚴格檢查。
+
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+false
+```
+
+# type.inferParamType
+
+未註解參數類型時，參數類型由函式傳入參數推斷。
+
+如果設定為 "false"，則在未註解時，參數類型為 "any"。
+
+
+## type
+
+```ts
+boolean
+```
+
+## default
+
+```jsonc
+false
+```
+
+# type.inferTableSize
+
+在類型推斷時最多分析的表欄位數。
+
+## type
+
+```ts
+integer
+```
+
+## default
+
+```jsonc
+10
+```
+
+# type.maxUnionVariants
+
+**Missing description!!**
+
+## type
+
+```ts
+integer
+```
+
+## default
+
+```jsonc
+0
+```
+
 # type.weakNilCheck
 
-When checking the type of union type, ignore the `nil` in it.
+對同位類型進行類型檢查時，忽略其中的 `nil`。
 
-When this setting is `false`, the `number|nil` type cannot be assigned to the `number` type. It can be with `true`.
+此設定為 `false` 時，`number|boolean` 類型無法賦值給 `number` 類型；為 `true` 時則可以。
 
 
 ## type
@@ -2111,7 +2329,7 @@ false
 
 同位類型中只要有一個子類型滿足條件，則同位類型也滿足條件。
 
-此設定為 `false` 時，`number|boolean` 類型無法賦給 `number` 類型；為 `true` 時則可以。
+此設定為 `false` 時，`number|boolean` 類型無法賦值給 `number` 類型；為 `true` 時則可以。
 
 
 ## type
@@ -2128,7 +2346,7 @@ false
 
 # typeFormat.config
 
-Configures the formatting behavior while typing Lua code.
+寫Lua程式碼時的格式化組態
 
 ## type
 
@@ -2141,15 +2359,15 @@ object<string, string>
 ```jsonc
 {
     /*
-    Controls if `end` is automatically completed at suitable positions.
+    是否在合適的位置自動完成 `end`
     */
     "auto_complete_end": "true",
     /*
-    Controls if a separator is automatically appended at the end of a table declaration.
+    是否在宣告表的結尾自動添加分隔符號
     */
     "auto_complete_table_sep": "true",
     /*
-    Controls if a line is formatted at all.
+    是否格式化某一行
     */
     "format_line": "true"
 }
@@ -2202,20 +2420,29 @@ true
 ## type
 
 ```ts
-string
+string | boolean
 ```
-
-## enum
-
-* ``"Ask"``
-* ``"Apply"``
-* ``"ApplyInMemory"``
-* ``"Disable"``
 
 ## default
 
 ```jsonc
-"Ask"
+null
+```
+
+# workspace.dofileRoots
+
+In addition to the current workspace, which directories `dofile` will treat as a possible root. The files in these directories will be loaded immediately.
+
+## type
+
+```ts
+Array<string>
+```
+
+## default
+
+```jsonc
+[]
 ```
 
 # workspace.ignoreDir
@@ -2268,7 +2495,7 @@ Array<string>
 
 # workspace.maxPreload
 
-最大預載入檔案數。
+最大預先載入檔案數。
 
 ## type
 
@@ -2284,7 +2511,7 @@ integer
 
 # workspace.preloadFileSize
 
-預載入時跳過大小大於該值（KB）的檔案。
+預先載入時跳過大小大於該值（KB）的檔案。
 
 ## type
 

--- a/locale/en-us/setting.lua
+++ b/locale/en-us/setting.lua
@@ -133,6 +133,8 @@ config.workspace.preloadFileSize  =
 "Skip files larger than this value (KB) when preloading."
 config.workspace.library          =
 "In addition to the current workspace, which directories will load files from. The files in these directories will be treated as externally provided code libraries, and some features (such as renaming fields) will not modify these files."
+config.workspace.dofileRoots          =
+"In addition to the current workspace, which directories `dofile` will treat as a possible root. The files in these directories will be loaded immediately."
 config.workspace.checkThirdParty  =
 [[
 Automatic detection and adaptation of third-party libraries, currently supported libraries are:

--- a/locale/es-419/setting.lua
+++ b/locale/es-419/setting.lua
@@ -134,6 +134,8 @@ config.workspace.preloadFileSize  =
 "Cuando se pre-carga, se omiten los archivos más grandes que este valor (en KB)."
 config.workspace.library          =
 "Además de los del espacio de trabajo actual, se cargan archivos de estos directorios. Los archivos en estos directorios serán tratados como bibliotecas con código externo y algunas características (como renombrar campos) no modificarán estos archivos."
+config.workspace.dofileRoots          = -- TODO: need translate!
+"In addition to the current workspace, which directories `dofile` will treat as a possible root. The files in these directories will be loaded immediately."
 config.workspace.checkThirdParty  =
 [[
 Detección y adaptación automática de bibliotecas externas. Actualmente soportadas:

--- a/locale/ja-jp/setting.lua
+++ b/locale/ja-jp/setting.lua
@@ -133,6 +133,8 @@ config.workspace.preloadFileSize  =
 "プリロード時にこの値（KB）より大きいファイルをスキップします。"
 config.workspace.library          =
 "現在のワークスペースに加えて、どのディレクトリからファイルをロードするか。これらのディレクトリ内のファイルは外部提供のコードライブラリとして扱われ、一部の機能（フィールド名の変更など）はこれらのファイルを変更しません。"
+config.workspace.dofileRoots          = -- TODO: need translate!
+"In addition to the current workspace, which directories `dofile` will treat as a possible root. The files in these directories will be loaded immediately."
 config.workspace.checkThirdParty  =
 [[
 サードパーティライブラリの自動検出と適応。現在サポートされているライブラリ：

--- a/locale/pt-br/setting.lua
+++ b/locale/pt-br/setting.lua
@@ -133,6 +133,8 @@ config.workspace.preloadFileSize  =
 "Ignorar arquivos maiores que este valor (KB) ao pré-carregar."
 config.workspace.library          =
 "Além da workspace atual, de quais diretórios carregar arquivos. Os arquivos nesses diretórios serão tratados como bibliotecas de código externas, e alguns recursos (como renomear campos) não modificarão esses arquivos."
+config.workspace.dofileRoots          = -- TODO: need translate!
+"In addition to the current workspace, which directories `dofile` will treat as a possible root. The files in these directories will be loaded immediately."
 config.workspace.checkThirdParty  =
 [[
 Detecção e adaptação automáticas de bibliotecas de terceiros; atualmente suportadas:

--- a/locale/zh-cn/setting.lua
+++ b/locale/zh-cn/setting.lua
@@ -132,6 +132,8 @@ config.workspace.preloadFileSize  =
 "预加载时跳过大小大于该值（KB）的文件。"
 config.workspace.library          =
 "除了当前工作区以外，还会从哪些目录中加载文件。这些目录中的文件将被视作外部提供的代码库，部分操作（如重命名字段）不会修改这些文件。"
+config.workspace.dofileRoots          = -- TODO: need translate!
+"In addition to the current workspace, which directories `dofile` will treat as a possible root. The files in these directories will be loaded immediately."
 config.workspace.checkThirdParty  =
 [[
 自动检测与适配第三方库，目前支持的库为：

--- a/locale/zh-tw/setting.lua
+++ b/locale/zh-tw/setting.lua
@@ -132,6 +132,8 @@ config.workspace.preloadFileSize  =
 "預先載入時跳過大小大於該值（KB）的檔案。"
 config.workspace.library          =
 "除了目前工作區以外，還會從哪些目錄中載入檔案。這些目錄中的檔案將被視作外部提供的程式碼庫，部分操作（如重新命名欄位）不會修改這些檔案。"
+config.workspace.dofileRoots          = -- TODO: need translate!
+"In addition to the current workspace, which directories `dofile` will treat as a possible root. The files in these directories will be loaded immediately."
 config.workspace.checkThirdParty  =
 [[
 自動偵測與適應第三方庫，目前支援的庫為：

--- a/script/config/template.lua
+++ b/script/config/template.lua
@@ -321,6 +321,7 @@ local template = {
     ['Lua.workspace.maxPreload']            = Type.Integer >> 5000,
     ['Lua.workspace.preloadFileSize']       = Type.Integer >> 500,
     ['Lua.workspace.library']               = Type.Array(Type.String),
+    ['Lua.workspace.dofileRoots']           = Type.Array(Type.String),
     ['Lua.workspace.checkThirdParty']       = Type.Or(Type.String >> 'Ask' << {
                                                 'Ask',
                                                 'Apply',

--- a/script/core/definition.lua
+++ b/script/core/definition.lua
@@ -81,7 +81,7 @@ local function checkRequire(source)
         return rpath.findUrisByRequireName(guide.getUri(source), literal)
     elseif libName == 'dofile'
     or     libName == 'loadfile' then
-        return workspace.findUrisByFilePath(literal)
+        return workspace.findUrisByFilePath(literal, guide.getUri(source))
     end
     return nil
 end

--- a/script/core/definition.lua
+++ b/script/core/definition.lua
@@ -81,7 +81,7 @@ local function checkRequire(source)
         return rpath.findUrisByRequireName(guide.getUri(source), literal)
     elseif libName == 'dofile'
     or     libName == 'loadfile' then
-        return workspace.findUrisByFilePath(literal, guide.getUri(source))
+        return workspace.findUrisByDofile(literal, guide.getUri(source))
     end
     return nil
 end

--- a/script/core/hover/description.lua
+++ b/script/core/hover/description.lua
@@ -15,7 +15,7 @@ local function collectRequire(mode, literal, uri)
         result, searchers = rpath.findUrisByRequireName(uri, literal)
     elseif mode == 'dofile'
     or     mode == 'loadfile' then
-        result = ws.findUrisByFilePath(literal)
+        result = ws.findUrisByFilePath(literal, uri)
     end
     if result and #result > 0 then
         local shows = {}

--- a/script/core/hover/description.lua
+++ b/script/core/hover/description.lua
@@ -15,7 +15,7 @@ local function collectRequire(mode, literal, uri)
         result, searchers = rpath.findUrisByRequireName(uri, literal)
     elseif mode == 'dofile'
     or     mode == 'loadfile' then
-        result = ws.findUrisByFilePath(literal, uri)
+        result = ws.findUrisByDofile(literal, uri)
     end
     if result and #result > 0 then
         local shows = {}

--- a/script/core/type-definition.lua
+++ b/script/core/type-definition.lua
@@ -79,7 +79,7 @@ local function checkRequire(source)
         return rpath.findUrisByRequireName(guide.getUri(source), literal)
     elseif libName == 'dofile'
     or     libName == 'loadfile' then
-        return workspace.findUrisByFilePath(literal, guide.getUri(source))
+        return workspace.findUrisByDofile(literal, guide.getUri(source))
     end
     return nil
 end

--- a/script/core/type-definition.lua
+++ b/script/core/type-definition.lua
@@ -79,7 +79,7 @@ local function checkRequire(source)
         return rpath.findUrisByRequireName(guide.getUri(source), literal)
     elseif libName == 'dofile'
     or     libName == 'loadfile' then
-        return workspace.findUrisByFilePath(literal)
+        return workspace.findUrisByFilePath(literal, guide.getUri(source))
     end
     return nil
 end

--- a/script/vm/compiler.lua
+++ b/script/vm/compiler.lua
@@ -2269,7 +2269,11 @@ local compilerSwitch = util.switch()
             if not returns then
                 return
             end
-            vm.setNode(source, vm.compileNode(returns[index]))
+            local returnType = returns[index]
+            if not returnType then
+                return
+            end
+            vm.setNode(source, vm.compileNode(returnType))
             return
         end
         local funcNode = vm.compileNode(func)

--- a/script/vm/compiler.lua
+++ b/script/vm/compiler.lua
@@ -8,7 +8,6 @@ local scope      = require 'workspace.scope'
 ---@class vm
 local vm         = require 'vm.vm'
 local plugin     = require 'plugin'
-local loading    = require 'workspace.loading'
 
 ---@class parser.object
 ---@field _compiledNodes        boolean

--- a/script/vm/compiler.lua
+++ b/script/vm/compiler.lua
@@ -8,6 +8,7 @@ local scope      = require 'workspace.scope'
 ---@class vm
 local vm         = require 'vm.vm'
 local plugin     = require 'plugin'
+local loading    = require 'workspace.loading'
 
 ---@class parser.object
 ---@field _compiledNodes        boolean
@@ -2260,8 +2261,7 @@ local compilerSwitch = util.switch()
             if not path or type(path) ~= 'string' then
                 return
             end
-            local ctx = workspace.rootUri
-            local uri = workspace.findUrisByFilePath(path, ctx)[1]
+            local uri = workspace.findUrisByDofile(path, guide.getUri(source))[1]
             if not uri then
                 return
             end

--- a/script/vm/compiler.lua
+++ b/script/vm/compiler.lua
@@ -1,3 +1,4 @@
+local workspace  = require 'workspace'
 local guide      = require 'parser.guide'
 local util       = require 'utility'
 local config     = require 'config'
@@ -2248,6 +2249,27 @@ local compilerSwitch = util.switch()
                 return
             end
             vm.setNode(source, vm.compileNode(ast))
+            return
+        end
+        if func.special == 'dofile' then
+            local pathArg = args[1]
+            if not pathArg or pathArg.type ~= 'string' then
+                return
+            end
+            local path = pathArg[1]
+            if not path or type(path) ~= 'string' then
+                return
+            end
+            local uri = workspace.findUrisByFilePath(path)[1]
+            if not uri then
+                return
+            end
+            local state = files.getState(uri)
+            local returns = state and state.ast and state.ast.returns and state.ast.returns[1]
+            if not returns then
+                return
+            end
+            vm.setNode(source, vm.compileNode(returns[index]))
             return
         end
         local funcNode = vm.compileNode(func)

--- a/script/vm/compiler.lua
+++ b/script/vm/compiler.lua
@@ -2260,7 +2260,8 @@ local compilerSwitch = util.switch()
             if not path or type(path) ~= 'string' then
                 return
             end
-            local uri = workspace.findUrisByFilePath(path)[1]
+            local sourceUri = guide.getUri(source)
+            local uri = workspace.findUrisByFilePath(path, sourceUri)[1]
             if not uri then
                 return
             end

--- a/script/vm/compiler.lua
+++ b/script/vm/compiler.lua
@@ -2260,8 +2260,8 @@ local compilerSwitch = util.switch()
             if not path or type(path) ~= 'string' then
                 return
             end
-            local sourceUri = guide.getUri(source)
-            local uri = workspace.findUrisByFilePath(path, sourceUri)[1]
+            local ctx = workspace.rootUri
+            local uri = workspace.findUrisByFilePath(path, ctx)[1]
             if not uri then
                 return
             end

--- a/script/workspace/workspace.lua
+++ b/script/workspace/workspace.lua
@@ -438,8 +438,11 @@ function m.findUrisByDofile(path, sourceUri)
     end
 
     for _, root in ipairs(roots) do
-        local rootUri = furi.encode(root)
-        addResult(m.getAbsolutePath(rootUri, path))
+        local rootPath = m.getAbsolutePath(sourceUri or m.rootUri, root)
+        if rootPath then
+            local rootUri = furi.encode(rootPath)
+            addResult(m.getAbsolutePath(rootUri, path))
+        end
     end
 
     if  m.rootUri then

--- a/script/workspace/workspace.lua
+++ b/script/workspace/workspace.lua
@@ -222,6 +222,7 @@ function m.getLibraryMatchers(scp)
     end
 
     local librarys = {}
+    local dofileRootsSet = {}
     for _, path in ipairs(config.get(scp.uri, 'Lua.workspace.library')) do
         local apath = m.getAbsolutePath(scp.uri, path)
         if apath then
@@ -231,7 +232,9 @@ function m.getLibraryMatchers(scp)
     for _, path in ipairs(config.get(scp.uri, 'Lua.workspace.dofileRoots')) do
         local apath = m.getAbsolutePath(scp.uri, path)
         if apath then
-            librarys[files.normalize(apath)] = true
+            local norm = files.normalize(apath)
+            librarys[norm] = true
+            dofileRootsSet[norm] = true
         end
     end
     local metaPaths = scp:get 'metaPaths'
@@ -252,7 +255,8 @@ function m.getLibraryMatchers(scp)
             }, globInteferFace)
             matchers[#matchers+1] = {
                 uri     = furi.encode(nPath),
-                matcher = matcher
+                matcher = matcher,
+                isDofile = dofileRootsSet[path] or false
             }
         end
     end
@@ -371,7 +375,9 @@ function m.awaitPreload(scp)
             end
             return true
         end))
-        scp:addLink(libMatcher.uri)
+        if not libMatcher.isDofile then
+            scp:addLink(libMatcher.uri)
+        end
         ---@async
         libMatcher.matcher:scan(furi.decode(libMatcher.uri), function (path)
             local uri = files.getRealUri(furi.encode(path))

--- a/script/workspace/workspace.lua
+++ b/script/workspace/workspace.lua
@@ -389,15 +389,32 @@ end
 
 --- 查找符合指定file path的所有uri
 ---@param path string
-function m.findUrisByFilePath(path)
+---@param contextUri? uri
+---@return uri[]
+function m.findUrisByFilePath(path, contextUri)
     if type(path) ~= 'string' then
         return {}
     end
-    local myUri = furi.encode(path)
+    -- Resolve relative paths using workspace context
+    ---@type string?
+    local resolvedPath = path
+    if contextUri and fs.path(path):is_relative() then
+        -- Extract directory from the context file URI
+        local contextPath = furi.decode(contextUri)
+        local contextDir = contextPath:match('^(.+[/\\])')
+        if contextDir then
+            resolvedPath = m.getAbsolutePath(furi.encode(contextDir), path)
+        end
+        if not resolvedPath then
+            return {}
+        end
+        ---@cast resolvedPath -?
+    end
+    local myUri = furi.encode(resolvedPath)
     local vm    = require 'vm'
     local resultCache = vm.getCache 'findUrisByFilePath.result'
-    if resultCache[path] then
-        return resultCache[path]
+    if resultCache[resolvedPath] then
+        return resultCache[resolvedPath]
     end
     local results = {}
     for uri in files.eachFile() do
@@ -405,7 +422,7 @@ function m.findUrisByFilePath(path)
             results[#results+1] = uri
         end
     end
-    resultCache[path] = results
+    resultCache[resolvedPath] = results
     return results
 end
 

--- a/script/workspace/workspace.lua
+++ b/script/workspace/workspace.lua
@@ -228,6 +228,12 @@ function m.getLibraryMatchers(scp)
             librarys[files.normalize(apath)] = true
         end
     end
+    for _, path in ipairs(config.get(scp.uri, 'Lua.workspace.dofileRoots')) do
+        local apath = m.getAbsolutePath(scp.uri, path)
+        if apath then
+            librarys[files.normalize(apath)] = true
+        end
+    end
     local metaPaths = scp:get 'metaPaths'
     log.debug('meta path:', inspect(metaPaths))
     if metaPaths then
@@ -389,35 +395,51 @@ end
 
 --- 查找符合指定file path的所有uri
 ---@param path string
----@param contextUri? uri
 ---@return uri[]
-function m.findUrisByFilePath(path, contextUri)
-    if type(path) ~= 'string' then
-        return {}
-    end
-    -- Resolve relative paths using provided contextUri (should be a folder URI)
-    ---@type string?
-    local resolvedPath = path
-    if contextUri and fs.path(path):is_relative() then
-        resolvedPath = m.getAbsolutePath(contextUri, path)
-        if not resolvedPath then
-            return {}
-        end
-        ---@cast resolvedPath -?
-    end
-    local myUri = furi.encode(resolvedPath)
+function m.findUrisByFilePath(path)
+    local uri = furi.encode(path)
     local vm    = require 'vm'
     local resultCache = vm.getCache 'findUrisByFilePath.result'
-    if resultCache[resolvedPath] then
-        return resultCache[resolvedPath]
+    if resultCache[path] then
+        return resultCache[path]
     end
     local results = {}
-    for uri in files.eachFile() do
-        if uri == myUri then
+    if files.exists(uri) then
+        results = { uri }
+    end
+    resultCache[path] = results
+    return results
+end
+
+
+---@param path string
+---@param sourceUri? uri
+---@return uri[]
+function m.findUrisByDofile(path, sourceUri)
+    if not fs.path(path):is_relative() then
+        return m.findUrisByFilePath(path)
+    end
+
+    ---@type string[]
+    local roots = config.get(sourceUri, 'Lua.workspace.dofileRoots')
+    local results = {}
+
+    local function addResult(absPath)
+        local uris = m.findUrisByFilePath(absPath)
+        for _, uri in ipairs(uris) do
             results[#results+1] = uri
         end
     end
-    resultCache[resolvedPath] = results
+
+    for _, root in ipairs(roots) do
+        local rootUri = furi.encode(root)
+        addResult(m.getAbsolutePath(rootUri, path))
+    end
+
+    if  m.rootUri then
+        addResult(m.getAbsolutePath(m.rootUri, path))
+    end
+
     return results
 end
 

--- a/script/workspace/workspace.lua
+++ b/script/workspace/workspace.lua
@@ -395,16 +395,11 @@ function m.findUrisByFilePath(path, contextUri)
     if type(path) ~= 'string' then
         return {}
     end
-    -- Resolve relative paths using workspace context
+    -- Resolve relative paths using provided contextUri (should be a folder URI)
     ---@type string?
     local resolvedPath = path
     if contextUri and fs.path(path):is_relative() then
-        -- Extract directory from the context file URI
-        local contextPath = furi.decode(contextUri)
-        local contextDir = contextPath:match('^(.+[/\\])')
-        if contextDir then
-            resolvedPath = m.getAbsolutePath(furi.encode(contextDir), path)
-        end
+        resolvedPath = m.getAbsolutePath(contextUri, path)
         if not resolvedPath then
             return {}
         end

--- a/test/crossfile/infer.lua
+++ b/test/crossfile/infer.lua
@@ -35,7 +35,7 @@ local function TEST(expect)
     local sourcePos, sourceUri
     for _, file in ipairs(expect) do
         local script, list = catch(file.content, '?')
-        local uri          = furi.encode(file.path)
+        local uri          = furi.encode(TESTROOT .. file.path)
         files.setText(uri, script)
         files.compileState(uri)
         if #list['?'] > 0 then
@@ -132,4 +132,24 @@ return 1337, "string", true
 local a, b, <?c?> = require 'a
 ]], },
     infer = 'nil',
+}
+
+TEST {
+    { path = 'a.lua', content = [[
+return 1337, "string", true
+]], },
+    { path = 'b.lua', content = [[
+local a, b, <?c?> = dofile 'a'
+]], },
+    infer = 'unknown',
+}
+
+TEST {
+    { path = 'a.lua', content = [[
+return 1337, "string", true
+]], },
+    { path = 'b.lua', content = [[
+local <?a?>, b, c = dofile 'a.lua'
+]], },
+    infer = 'integer',
 }

--- a/tools/build-doc.lua
+++ b/tools/build-doc.lua
@@ -1,5 +1,6 @@
-package.path = package.path .. ';script/?.lua;tools/?.lua'
+package.path = package.path .. ';script/?.lua;tools/?.lua;script/?/init.lua'
 
+log = require 'log'
 local fs       = require 'bee.filesystem'
 local config   = require 'configuration'
 local markdown = require 'provider.markdown'


### PR DESCRIPTION
This adds type inference for `dofile` similar to how `require` works. Also adds a new setting `Lua.workspace.dofileRoots` to control what `dofile` considers a root. The doc generator seemingly hasn't been run in a long time which is why the doc changes are so big, potentially merge from `chore: changelog` if you don't want the docs changes.