### PR TITLE
fix: method-level generic return type overwritten by receiver class generic resolution

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 * `FIX` Deduplicate documentation bindings for parameters
 * `FIX` Correct `math.type` meta return annotation to use `nil` instead of the string literal `'nil'`
 * `FIX` Fix initial `nameStyle.config` not getting loaded in the appropriate workspace.
+* `FIX` Fix method-level generic return type being overwritten by receiver class generic resolution [#3438](https://github.com/LuaLS/lua-language-server/discussions/3438)
 
 ## 3.18.2
 * `CHG` `duplicate-set-field` diagnostic now supports linked suppression: when any occurrence of a duplicate field is suppressed with `---@diagnostic disable` or `---@diagnostic disable-next-line`, all warnings for that field name will be suppressed

--- a/script/vm/compiler.lua
+++ b/script/vm/compiler.lua
@@ -1752,13 +1752,25 @@ local function bindReturnOfFunction(source, mfunc, index, args)
                                     if doc.type == 'doc.return' then
                                         for _, rtn in ipairs(doc.returns) do
                                             if rtn.returnIndex == index then
-                                                local newRtn = vm.cloneObject(rtn, genericMap)
-                                                if newRtn then
-                                                    returnNode = vm.compileNode(newRtn)
-                                                    for rnode in returnNode:eachObject() do
-                                                        if rnode.type == 'generic' then
-                                                            returnNode = rnode:resolve(guide.getUri(source), args)
-                                                            break
+                                                -- Only clone if the return type only references class-level generics
+                                                -- (i.e. generics that exist in the genericMap from the receiver).
+                                                -- Method-level generics (e.g. V not in {T=string}) are
+                                                -- already resolved correctly in the first round above.
+                                                local onlyClassGenerics = true
+                                                guide.eachSourceType(rtn, 'doc.generic.name', function(src)
+                                                    if not genericMap[src[1]] then
+                                                        onlyClassGenerics = false
+                                                    end
+                                                end)
+                                                if onlyClassGenerics then
+                                                    local newRtn = vm.cloneObject(rtn, genericMap)
+                                                    if newRtn then
+                                                        returnNode = vm.compileNode(newRtn)
+                                                        for rnode in returnNode:eachObject() do
+                                                            if rnode.type == 'generic' then
+                                                                returnNode = rnode:resolve(guide.getUri(source), args)
+                                                                break
+                                                            end
                                                         end
                                                     end
                                                 end

--- a/test/type_inference/common.lua
+++ b/test/type_inference/common.lua
@@ -5215,3 +5215,21 @@ local mylist
 
 local <?result?> = mylist:identity()
 ]]
+
+-- Discussion #3438: Method-level generic return type not clobbered by receiver block
+-- When a generic class method has @return R where R is method-only (not in class genericMap),
+-- the receiver block should not overwrite Round 1's correct resolution.
+TEST 'integer' [[
+---@class MyClass<T>
+local MyClass = {}
+
+---@generic R
+---@param val R
+---@return R
+function MyClass:pass(val) return val end
+
+---@type MyClass<string>
+local myClass
+
+local <?result?> = myClass:pass(42)
+]]


### PR DESCRIPTION
Closes a regression where `@return R` on a generic class method resolves to `unknown` when `R` is method-level (not in the class genericMap).

The receiver block was overwriting Round 1's correct resolution with a clone using only the class generic map, leaving method-level generics unresolved.

Fix: scout-before-clone — skip the receiver block if the return doc references generics not present in the class genericMap.

See discussion for full report and TL;DR: https://github.com/LuaLS/lua-language-server/discussions/3438#discussioncomment-17785177

---

## 中文版

generic class method 的 `@return` 如果用了 method-level 的 generic（例如 `@return R`，而 `R` 不在 class 的 generic 參數裡），回傳值會錯誤地變成 `unknown`。

原因是 receiver block 只拿了 class genericMap（如 `{T=string}`）去 clone return doc，沒在 map 裡的 generic（如 `R`）會留 unresolved，直接蓋掉 Round 1 已經正確解好的結果。

修法：scout-before-clone — clone 前先掃 return doc 有沒有 generic name 不在 genericMap 中，有就 skip receiver block，保留 Round 1 的答案。

詳細的 TL;DR 與 report 請見上面的 discussion link。

---

**PS**:
- 使用 claude code + `deepseek-v4-flash` debug 的
- 頭幾個 session 效果不佳 🤷‍♂️ 能找到相關代碼位置但 fix 方向極複雜且無效
- 最後還是要給他一些 insight 才搞得定 😅
當時我只有 insight 但不知怎樣改，在我說完 insight 後 deepseek 就說 `你的分析是對的` 然後他就搞定了 🤣
- 然後我再讓他打磨了下，和加上 test case & changelog