### PR TITLE
Infer pcall's own return when the called function has none

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 <!-- Add all new changes here. They will be moved under a version at release -->
+* `FIX` Infer `pcall`/`xpcall` second result from their own declaration when the called function returns nothing [#3440](https://github.com/LuaLS/lua-language-server/pull/3440)
 * `NEW` Support type inference for `@field` and `@type` function declarations in method overrides [#3367](https://github.com/LuaLS/lua-language-server/issues/3367)
 * `FIX` Deduplicate documentation bindings for parameters
 * `FIX` Correct `math.type` meta return annotation to use `nil` instead of the string literal `'nil'`

--- a/script/vm/compiler.lua
+++ b/script/vm/compiler.lua
@@ -2191,12 +2191,14 @@ local compilerSwitch = util.switch()
                 newArgs[#newArgs+1] = args[i]
             end
             local node = getReturn(args[1], index - 1, newArgs)
-            if node then
+            if node and not node:isEmpty() then
                 vm.setNode(source, node)
+                return
             end
-            return
-        end
-        if func.special == 'xpcall' and index > 1 then
+            -- The called function has no such return, but `pcall` still does: on failure
+            -- the second result is the error value. Fall through to its own declaration,
+            -- otherwise the result stays unknown.
+        elseif func.special == 'xpcall' and index > 1 then
             if not args then
                 return
             end
@@ -2205,10 +2207,12 @@ local compilerSwitch = util.switch()
                 newArgs[#newArgs+1] = args[i]
             end
             local node = getReturn(args[1], index - 1, newArgs)
-            if node then
+            if node and not node:isEmpty() then
                 vm.setNode(source, node)
+                return
             end
-            return
+            -- Same as `pcall`: the message handler's result comes in place of the missing
+            -- return, and its type is declared on `xpcall` itself.
         end
         if func.special == 'require' then
             if index == 2 then

--- a/test/type_inference/common.lua
+++ b/test/type_inference/common.lua
@@ -320,6 +320,20 @@ end
 _, <?y?> = xpcall(x)
 ]]
 
+-- A declared function without returns leaves nothing to take the second result from, but
+-- `pcall` still has one of its own: the error value.
+TEST 'any' [[
+---@type fun()
+local x
+_, <?y?> = pcall(x)
+]]
+
+TEST 'any' [[
+---@type fun()
+local x
+_, <?y?> = xpcall(x, debug.traceback)
+]]
+
 TEST 'A' [[
 ---@class A
 


### PR DESCRIPTION
`pcall` returns `false` plus the error value when the call fails, and the meta declares that second result as `any`. For a function declared as `fun()` it came out as `unknown` instead:

```lua
---@type fun()
local task

local ok, err = pcall(task)   -- err: unknown, expected any
```

The compiler takes the called function's return under the same index and stops there. `getReturn` always yields a node — an empty one when there is nothing to take — so the `if node then` guard passed even when the function returns nothing, and that empty node became the result.

An empty node is no longer accepted as an answer: compilation falls through to `pcall`'s own declaration. The same applies to `xpcall`, where the message handler's result takes the place of the missing return.

Functions that do return a value are unaffected — the existing tests cover that, and two new ones cover the case above.
