### PR TITLE
Recognize a class inheriting a generic one as a child of its parent

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 <!-- Add all new changes here. They will be moved under a version at release -->
+* `FIX` Recognize a class inheriting a generic class as a child of that generic's own parent [#3441](https://github.com/LuaLS/lua-language-server/pull/3441)
 * `NEW` Support type inference for `@field` and `@type` function declarations in method overrides [#3367](https://github.com/LuaLS/lua-language-server/issues/3367)
 * `FIX` Deduplicate documentation bindings for parameters
 * `FIX` Correct `math.type` meta return annotation to use `nil` instead of the string literal `'nil'`

--- a/script/vm/type.lua
+++ b/script/vm/type.lua
@@ -589,9 +589,21 @@ function vm.isSubType(uri, child, parent, mark, errs)
             for _, set in ipairs(childClass:getSets(uri)) do
                 if set.type == 'doc.class' and set.extends then
                     for _, ext in ipairs(set.extends) do
-                        if  ext.type == 'doc.extends.name'
-                        and (not isBasicType or guide.isBasicType(ext[1]))
-                        and vm.isSubType(uri, ext[1], parent, mark, errs) == true then
+                        -- A parent given with arguments (`---@class A : B<string>`) is
+                        -- parsed into `doc.type.sign`, keeping the name one level down.
+                        -- Without looking inside, such a parent is skipped entirely and
+                        -- the class is not recognized as its child.
+                        local extName
+                        if ext.type == 'doc.extends.name' then
+                            extName = ext[1]
+                        elseif ext.type == 'doc.type.sign'
+                        and    ext.node
+                        and    ext.node.type == 'doc.extends.name' then
+                            extName = ext.node[1]
+                        end
+                        if  extName
+                        and (not isBasicType or guide.isBasicType(extName))
+                        and vm.isSubType(uri, extName, parent, mark, errs) == true then
                             mark[childName] = nil
                             return true
                         end

--- a/test/diagnostics/param-type-mismatch.lua
+++ b/test/diagnostics/param-type-mismatch.lua
@@ -394,4 +394,23 @@ local function f(y) end
 f(x)
 ]]
 
+-- A class inheriting a generic one is still a child of that generic's own parent: the
+-- parent given with arguments is parsed one level down and used to be skipped.
+TEST [[
+---@class Base
+
+---@class Middle<T> : Base
+---@field Value T
+
+---@class Child : Middle<boolean>
+
+---@param value Base
+local function f(value) end
+
+---@type Child
+local child
+
+f(child)
+]]
+
 config.set(nil, 'Lua.type.checkTableShape', false)


### PR DESCRIPTION
A class inheriting a generic one was not recognized as a child of what that generic itself inherits:

```lua
---@class Component

---@class Typed<T> : Component
---@field Value T

---@class Toggle : Typed<boolean>

---@param component Component
local function mount(component) end

---@type Toggle
local toggle

mount(toggle)   -- Cannot assign `Toggle` to parameter `Component`
```

A parent given with arguments is parsed into `doc.type.sign`, which keeps the name one level down. The inheritance walk in `vm.isSubType` only looked at `doc.extends.name`, so such a parent was skipped entirely and the chain broke at that point.

The name is now taken from the sign node as well. A test in `param-type-mismatch` covers the case above.
