### PR TITLE
Resolve unbound class generics to any

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 <!-- Add all new changes here. They will be moved under a version at release -->
+* `FIX` Resolve unbound class generic parameters to `any` instead of leaving the parameter as the field type [#3442](https://github.com/LuaLS/lua-language-server/pull/3442)
 * `NEW` Support type inference for `@field` and `@type` function declarations in method overrides [#3367](https://github.com/LuaLS/lua-language-server/issues/3367)
 * `FIX` Deduplicate documentation bindings for parameters
 * `FIX` Correct `math.type` meta return annotation to use `nil` instead of the string literal `'nil'`

--- a/script/vm/compiler.lua
+++ b/script/vm/compiler.lua
@@ -304,20 +304,43 @@ function vm.getClassGenericMap(uri, classGlobal, signs)
     return nil
 end
 
+---Maps every declared generic parameter of a class to `any`.
+---
+---Used when a generic class is referenced without arguments (`---@type Box` instead of
+---`Box<string>`). Its fields would otherwise keep the parameter itself as their type,
+---which no value can ever have, making the field unusable and every place that mentions
+---the class without arguments a false error.
 ---@param uri uri
 ---@param classGlobal vm.global
+---@return table<string, vm.node>?
+local function getClassAnyGenericMap(uri, classGlobal)
+    for _, set in ipairs(classGlobal:getSets(uri)) do
+        if set.type == 'doc.class' and set.signs then
+            local resolved = {}
+            local anyNode = vm.createNode()
+            anyNode:merge(vm.declareGlobal('type', 'any'))
+            for _, signName in ipairs(set.signs) do
+                if signName[1] then
+                    resolved[signName[1]] = anyNode
+                end
+            end
+            if next(resolved) then
+                return resolved
+            end
+            break
+        end
+    end
+    return nil
+end
+
 ---@param field parser.object | vm.generic
----@param signs parser.object[]
+---@param resolved table<string, vm.node>
 ---@return parser.object?
-local function resolveGenericField(uri, classGlobal, field, signs)
+local function resolveFieldWithMap(field, resolved)
     if field.type ~= 'doc.field' or not field.extends then
         return nil
     end
     if not containsGenericName(field.extends) then
-        return nil
-    end
-    local resolved = vm.getClassGenericMap(uri, classGlobal, signs)
-    if not resolved then
         return nil
     end
     local newExtends = vm.cloneObject(field.extends, resolved)
@@ -334,6 +357,25 @@ local function resolveGenericField(uri, classGlobal, field, signs)
         visible  = field.visible,
         optional = field.optional,
     }
+end
+
+---@param uri uri
+---@param classGlobal vm.global
+---@param field parser.object | vm.generic
+---@param signs parser.object[]
+---@return parser.object?
+local function resolveGenericField(uri, classGlobal, field, signs)
+    if field.type ~= 'doc.field' or not field.extends then
+        return nil
+    end
+    if not containsGenericName(field.extends) then
+        return nil
+    end
+    local resolved = vm.getClassGenericMap(uri, classGlobal, signs)
+    if not resolved then
+        return nil
+    end
+    return resolveFieldWithMap(field, resolved)
 end
 
 local searchFieldSwitch = util.switch()
@@ -493,6 +535,13 @@ local searchFieldSwitch = util.switch()
             end
         end
         if node.cate == 'type' then
+            local resolved = getClassAnyGenericMap(suri, node)
+            if resolved then
+                vm.getClassFields(suri, node, key, function (field, isMark)
+                    pushResult(resolveFieldWithMap(field, resolved) or field, isMark)
+                end)
+                return
+            end
             vm.getClassFields(suri, node, key, pushResult)
         end
     end)

--- a/test/type_inference/common.lua
+++ b/test/type_inference/common.lua
@@ -320,6 +320,29 @@ end
 _, <?y?> = xpcall(x)
 ]]
 
+-- A generic class used without arguments: the parameter has nothing to resolve to, and
+-- keeping it as the field's type would leave a type no value can have.
+TEST 'any' [[
+---@class Storage<T>
+---@field Value T
+
+---@type Storage
+local storage
+local value = storage.Value
+print(<?value?>)
+]]
+
+-- Arguments still win where they are given.
+TEST 'string' [[
+---@class Storage2<T>
+---@field Value T
+
+---@type Storage2<string>
+local storage
+local value = storage.Value
+print(<?value?>)
+]]
+
 TEST 'A' [[
 ---@class A
 


### PR DESCRIPTION
A generic class can be referenced without arguments. Its fields kept the parameter itself as their type, displayed as `<T>` — a type no value can ever have:

```lua
---@class Repository<T>
---@field Items T[]
---@field Get fun(self: Repository, index: integer): T

---@type Repository
local repo

local items = repo.Items      -- <T>
local first = repo:Get(1)     -- <T>
```

## Why this matters beyond cosmetics

It effectively rules out adding a parameter to an existing, widely used class. Consider a store that holds elements of many kinds and hands them to code that knows exactly what it works with:

```lua
---@class Element
---@field Id integer
---@field Value any

---@class Store
---@field ById table<integer, Element>

---@param element Element
local function register(element) end
```

Turning `Element` into `Element<T>` is exactly the right move for the consumers — a toggle wants `Element<boolean>`, a slider wants `Element<number>`. But every place that legitimately does not care about the parameter — the store, the registry, the traversal helpers, the `register` signature — suddenly deals in `<T>`. In a codebase of any size that is dozens of mentions, and the only escape is writing `Element<any>` in each of them: noise that says nothing and has to be maintained forever.

The alternative workaround is worse: declaring a second, "typed" subclass purely to carry the parameter, duplicating a class for no reason other than to satisfy the checker.

## What this changes

Unbound parameters resolve to `any`, so those places behave exactly as before the class gained a parameter, while explicit arguments still win:

```lua
---@type Repository<string>
local named
local values = named.Items    -- string[]
```

This holds for methods as well, not only fields, and matches what writing `Repository<any>` by hand already does today.

## Why `any` and not `unknown`

`unknown` reads as "inference failed" and is reported by `no-unknown`; here nothing failed — the parameter was simply never bound, and the value genuinely can be anything. `any` also keeps the promise that adding a parameter to a class does not change how existing code is checked.

Worth noting for symmetry: an unbound parameter of a generic *function* still yields `unknown`, so the two are not aligned. If you would rather have both behave the same, say which way and I will follow.

## Other uses this opens up

Gradual typing of an existing hierarchy — add the parameter to a base class today, annotate consumers one by one, and untouched code keeps working. Container-like classes (`Queue<T>`, `Cache<T>`, `Result<T>`) can be referenced generically in plumbing and precisely at the point of use.
