### PR TITLE
fix: ensure JSON output is valid UTF-8

### DIFF
--- a/script/json.lua
+++ b/script/json.lua
@@ -18,6 +18,7 @@ local huge = math.huge
 local tiny = -huge
 
 local utf8_char
+local utf8_len
 local math_type
 
 if _VERSION == "Lua 5.1" or _VERSION == "Lua 5.2" then
@@ -51,6 +52,7 @@ if _VERSION == "Lua 5.1" or _VERSION == "Lua 5.2" then
     end
 else
     utf8_char = utf8.char
+    utf8_len = utf8.len
     math_type = math.type
 end
 
@@ -118,7 +120,26 @@ encode_map["nil"] = function ()
     return "null"
 end
 
+local function replace_invalid_utf8(v)
+    local result = {}
+    local start = 1
+    while true do
+        local _, invalid = utf8_len(v, start)
+        if not invalid then
+            result[#result+1] = string_sub(v, start)
+            break
+        end
+        result[#result+1] = string_sub(v, start, invalid - 1)
+        result[#result+1] = utf8_char(0xfffd)
+        start = invalid + 1
+    end
+    return table_concat(result)
+end
+
 local function encode_string(v)
+    if utf8_len and not utf8_len(v) then
+        v = replace_invalid_utf8(v)
+    end
     return string_gsub(v, '[%z\1-\31\\"]', encode_escape_map)
 end
 

--- a/test/other/init.lua
+++ b/test/other/init.lua
@@ -1,1 +1,2 @@
 --require 'other.filewatch'
+require 'other.json'

--- a/test/other/json.lua
+++ b/test/other/json.lua
@@ -1,0 +1,25 @@
+local json = require 'json'
+
+local replacement = utf8.char(0xfffd)
+
+local function assertEncoding(value, expected)
+    local encoded = json.encode(value)
+    assert(utf8.len(encoded))
+    assert(encoded == expected, ('expected %q, got %q'):format(expected, encoded))
+end
+
+assertEncoding('plain text', '"plain text"')
+assertEncoding('é中文', '"é中文"')
+assertEncoding('\x80', '"' .. replacement .. '"')
+assertEncoding('\xff', '"' .. replacement .. '"')
+assertEncoding('\xc2A', '"' .. replacement .. 'A"')
+assertEncoding('\xe2\x82', '"' .. replacement .. replacement .. '"')
+assertEncoding('[^%w_\x80-\xff]', '"[^%w_' .. replacement .. '-' .. replacement .. ']"')
+assertEncoding({ ['\x80'] = 'value' }, '{"' .. replacement .. '":"value"}')
+
+assert(json.decode(json.encode('\x80')) == replacement)
+
+local jsonb = require 'json-beautify'
+local beautified = jsonb.beautify({ value = '\x80' })
+assert(utf8.len(beautified))
+assert(beautified:find(replacement, 1, true))


### PR DESCRIPTION
## Summary

Lua strings are byte arrays, so a literal such as `"\x80"` can contain bytes that are not valid UTF-8. The JSON encoder previously copied those bytes unchanged, producing JSON and LSP bodies that strict UTF-8 decoders reject.

Validate strings at the JSON boundary and replace each invalid byte with U+FFFD before applying the existing JSON escapes. Valid UTF-8 is unchanged. Lua 5.1 and 5.2 keep the previous behavior because they do not provide `utf8.len`.

The repository itself contains a trigger in `script/parser/guide.lua`:

```lua
m.notNamePattern = '[^%w_\x80-\xff]'
```

Requesting document symbols evaluates that literal and puts its byte-string value into `detail`. Before this change, the response contained raw bytes `0x80` and `0xff`. Afterwards it contains replacement characters and the complete response is valid UTF-8.

This intentionally fixes the serialization boundary only. Producer-specific escaping is a separate display policy and is not necessary to guarantee valid JSON output.

Related: #2983. The beautified JSON encoder used by documentation export shares the repaired string encoder and is covered by the new test.

## Validation

- `3rd/luamake/luamake`: all 110 bee tests pass (3 skipped), followed by the complete LuaLS test suite.
- End-to-end LSP session against the built server: `initialize`, `didOpen` for `script/parser/guide.lua`, and `textDocument/documentSymbol`; all 191,911 captured protocol bytes decode as UTF-8 and the trigger's detail is `"[^%w_�-�]"`.
- 20,000 randomized byte strings all encode to valid UTF-8.
- Regression coverage includes valid non-ASCII text, malformed multibyte sequences, object keys, round-tripping repaired output, and beautified JSON.

## Performance

A synthetic benchmark repeatedly encoded a document-symbol-shaped response with 250 symbols. Across five alternating runs, median time increased from 3.678s to 3.884s (+5.6%). Valid strings pay for the C `utf8.len` scan; allocation and repair occur only for invalid input.
