### PR TITLE
fix: return single definition for anonymous-function field assignment

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ## Unreleased
 <!-- Add all new changes here. They will be moved under a version at release -->
 * `FIX` `need-check-nil` diagnostic is no longer reported on safe navigation access (e.g. `x?.field`, `f?.()`, `t?.[key]`), since the optional access itself already handles the nil check. Note that a non-safe access chained after a safe one (e.g. `x.upper()?.field`) still reports, because the safe access only protects its own result.
+* `FIX` Go to definition on a table field assigned an anonymous function (e.g. `A.c = function() end`) now returns a single definition at the field name, instead of two candidates (the field name and the function value) [#2451](https://github.com/LuaLS/lua-language-server/issues/2451)
 
 ## 3.19.1
 `2026-08-14`

--- a/script/core/definition.lua
+++ b/script/core/definition.lua
@@ -231,6 +231,25 @@ return function (uri, offset)
         return nil
     end
 
+    -- Drop a redundant function-value target when the owning assignment's name node is also a target.
+    -- Collapses `A.c = function() end` to a single definition at the name `c`.
+    local targetMark = {}
+    for _, res in ipairs(results) do
+        targetMark[res.target] = true
+    end
+    for i = #results, 1, -1 do
+        local target = results[i].target
+        if target.type == 'function' then
+            local parent = target.parent
+            if parent and guide.isAssign(parent) then
+                local owner = parent.field or parent.method or parent.index or parent.variable or parent
+                if targetMark[owner] then
+                    table.remove(results, i)
+                end
+            end
+        end
+    end
+
     sortResults(results)
     jumpSource(results)
 

--- a/test/definition/field.lua
+++ b/test/definition/field.lua
@@ -21,3 +21,15 @@ local t = X
 
 print(t.x.<?y?>)
 ]]
+
+TEST [[
+A = {}
+A.<!c!> = function() end
+A.<?c?>()
+]]
+
+TEST [[
+local A = {}
+A.<!c!> = function() end
+A.<?c?>()
+]]

--- a/test/definition/function.lua
+++ b/test/definition/function.lua
@@ -24,6 +24,6 @@ end
 ]]
 
 TEST [[
-local <!f!> = <!function () end!>
+local <!f!> = function () end
 <?f?>()
 ]]


### PR DESCRIPTION
Fixes #2451

## Summary

Go to definition on a field assigned an anonymous function returned **two candidates** on the same line — the field name and the function value.

```lua
A = {}
A.c = function() end
A.c()   -- goto definition on `c` previously returned 2 candidates: `c` and `function`
```

`local f = function() end` behaves the same way. After this PR, only the field name is returned, consistent with how literal values already behave (e.g. `X.y = 1` jumps to `y`).

<details>
<summary>Root cause (click to expand)</summary>

`vm.getDefs` produces two independent defs through two paths:

1. **Name candidate (`c`)**: `compileByNodeChain` resolves the `setfield` LHS, and the definition provider unwraps it via `src.field`.

2. **Function-value candidate (`function`)**: `searchByNode` → `compileNode` merges the field's *value* into the compiled type. The `function` node survives the literal filter because function literals are explicitly exempted there — an exemption meant for generic type inference (e.g. `v2 = f(function() end)`), not for direct assignments.

Neither existing dedup catches it:

- node-identity dedup in `getDefs` treats them as different nodes;

- the nested-range dedup in `sortResults` only removes a target whose range *contains* another — these two are same-line siblings.

</details>

<details>
<summary>Fix (click to expand)</summary>

In `script/core/definition.lua`, after collecting targets, drop a function-value target when its owning assignment's name node is **also** a target:

```lua
local targetMark = {}
for _, res in ipairs(results) do
    targetMark[res.target] = true
end
for i = #results, 1, -1 do
    local target = results[i].target
    if target.type == 'function' then
        local parent = target.parent
        if parent and guide.isAssign(parent) then
            local owner = parent.field or parent.method or parent.index or parent.variable or parent
            if targetMark[owner] then
                table.remove(results, i)
            end
        end
    end
end
```

Why this shape:

- Conditioned on the **owner also being a target**, so generic-inference defs (where the function literal is the only candidate) are left untouched.

- Scoped to the definition provider only. `type-definition` and `implementation` already return a single candidate through their own filters (a type whitelist and `getRefs` + `isAssign` respectively), so they are unaffected.

</details>

## Tests

- Updated `test/definition/function.lua`: `local f = function() end` now expects a single definition at `f`.

- Added `test/definition/field.lua` regression cases for both global and local tables (`A.c = function() end`).

- Full test suite passes.

---

## 中文摘要

`A.c = function() end` 的寫法，goto definition 原本會回傳兩個結果（欄位名稱 `c` 和 function 值）。此 PR 在 `definition.lua` 加了一段處理：當欄位名稱也在結果中時，移除冗餘的 function 值，只保留名稱節點，與 `X.y = 1` 跳到 `y` 的慣例一致。type-definition / implementation 兩個 provider 因各自已有 filter，不受影響；測試全部通過。

此 bug 的根源，是 `function` 字面量豁免在 2022 年某次 global-manager/infer 大型 refactor (https://github.com/LuaLS/lua-language-server/commit/0e159ee037) 中順手加入的，屬 refactor 的副作用、並非刻意設計；回傳 2 個 candidate 的測試也是同期的批量 `update` commit (https://github.com/LuaLS/lua-language-server/commit/9451329b33) 帶入的。

**本 PR 由 Claude Code（deepseek-v4-flash）協助分析與撰寫。**
