### PR TITLE
fix: more invalid UTF-8 JSON in hover/completions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ## Unreleased
 <!-- Add all new changes here. They will be moved under a version at release -->
 * `FIX` `need-check-nil` diagnostic is no longer reported on safe navigation access (e.g. `x?.field`, `f?.()`, `t?.[key]`), since the optional access itself already handles the nil check. Note that a non-safe access chained after a safe one (e.g. `x.upper()?.field`) still reports, because the safe access only protects its own result.
+* `FIX` Prevent hover and enum completion responses from containing invalid UTF-8 when escaped string literals decode to arbitrary bytes (e.g. `"\xC2"`).
 
 ## 3.19.1
 `2026-08-14`

--- a/script/core/completion/completion.lua
+++ b/script/core/completion/completion.lua
@@ -1277,7 +1277,7 @@ local function insertDocEnumKey(doc, enums)
                 goto CONTINUE
             end
             enums[#enums+1] = {
-                label  = ('%q'):format(key),
+                label  = util.viewLiteral(key),
                 kind   = define.CompletionItemKind.EnumMember,
                 id     = stack(field, function (newField) ---@async
                     return {

--- a/script/core/hover/description.lua
+++ b/script/core/hover/description.lua
@@ -64,10 +64,11 @@ local function asStringView(source, literal)
     if  config.get(guide.getUri(source), 'Lua.hover.viewString')
     and (source[2] == '"' or source[2] == "'")
     and rawLen > #literal then
-        local view = literal
+        local view = util.escapeInvalidUtf8(literal)
         local max = config.get(guide.getUri(source), 'Lua.hover.viewStringMax')
         if #view > max then
-            view = view:sub(1, max) .. '...'
+            local nextCharacter = utf8.offset(view, 0, max + 1)
+            view = view:sub(1, nextCharacter - 1) .. '...'
         end
         local md = markdown()
         md:add('txt', view)
@@ -486,7 +487,7 @@ local function tryDocEnum(source)
                 if not key then
                     goto CONTINUE
                 end
-                keys[#keys+1] = ('%q'):format(key)
+                keys[#keys+1] = util.viewLiteral(key)
                 ::CONTINUE::
             end
         end
@@ -507,7 +508,8 @@ local function tryDocEnum(source)
                 end
                 if field.value.type == 'integer'
                 or field.value.type == 'string' then
-                    md:add('lua', ('    %s: %s = %q,'):format(key, field.value.type, field.value[1]))
+                    local value = util.viewLiteral(field.value[1])
+                    md:add('lua', ('    %s: %s = %s,'):format(key, field.value.type, value))
                 end
                 if field.value.type == 'binary'
                 or field.value.type == 'unary' then

--- a/script/utility.lua
+++ b/script/utility.lua
@@ -469,7 +469,10 @@ local esc = {
     ['\n'] = '\\\n',
 }
 
-local function escapeInvalidUtf8(str)
+function m.escapeInvalidUtf8(str)
+    if utf8Len(str) then
+        return str
+    end
     local result = {}
     local start = 1
     while true do
@@ -486,9 +489,7 @@ local function escapeInvalidUtf8(str)
 end
 
 function m.viewString(str, quo)
-    if not utf8Len(str) then
-        str = escapeInvalidUtf8(str)
-    end
+    str = m.escapeInvalidUtf8(str)
     if not quo then
         if str:find('[\r\n]') then
             quo = '[['

--- a/test/completion/common.lua
+++ b/test/completion/common.lua
@@ -3880,6 +3880,24 @@ f(<??>)
 }
 
 TEST [[
+---@enum(key) Enum
+local t = {
+    ["\xC2"] = 1,
+}
+
+---@param p Enum
+local function f(p) end
+
+f(<??>)
+]]
+{
+    {
+        label    = '"\\194"',
+        kind     = define.CompletionItemKind.EnumMember,
+    },
+}
+
+TEST [[
 ---@class optional
 ---@field enum enum
 

--- a/test/hover/init.lua
+++ b/test/hover/init.lua
@@ -2,6 +2,7 @@ local core       = require 'core.hover'
 local files      = require 'files'
 local catch      = require 'catch'
 local config     = require 'config'
+local json       = require 'json'
 
 rawset(_G, 'TEST', true)
 
@@ -12,8 +13,18 @@ function TEST(script)
         files.setText(TESTURI, newScript)
         local hover = core.byUri(TESTURI, catched['?'][1][1], 1)
         assert(hover)
+        local value = hover:string():gsub('\r\n', '\n')
+        assert(utf8.len(value))
+        assert(utf8.len(json.encode {
+            result = {
+                contents = {
+                    kind  = 'markdown',
+                    value = value,
+                },
+            },
+        }))
         expect = expect:gsub('^[\r\n]*(.-)[\r\n]*$', '%1'):gsub('\r\n', '\n')
-        local label = hover:string():gsub('\r\n', '\n'):match('```lua[\r\n]*(.-)[\r\n]*```')
+        local label = value:match('```lua[\r\n]*(.-)[\r\n]*```')
         assert(expect == label)
         files.remove(TESTURI)
     end
@@ -372,6 +383,11 @@ TEST [[
 local s = <?'abc中文'?>
 ]]
 [[9 个字节，5 个字符]]
+
+TEST [[
+local fail = <?"\xC2"?>
+]]
+[[1 个字节]]
 
 TEST [[
 local n = <?0xff?>
@@ -2126,6 +2142,22 @@ local m = {
 [[
 (enum) A
 ]]
+
+TEST [[
+---@enum <?Broken?>
+local Broken = {
+    A = "\xC2",
+}
+]]
+[[(enum) Broken]]
+
+TEST [[
+---@enum(key) <?Key?>
+local Key = {
+    ["\xC2"] = 1,
+}
+]]
+[[(enum) Key]]
 
 TEST [[
 local <?x?> = 1 << 2


### PR DESCRIPTION
It is possible for lua-language-server to send invalid utf-8.
Some clients (e.g. Zed) will drop the connection if an LSP sends invalid data. 

Hovering this will trigger the invalid UTF-8 in the response.
```lua
local fail = "\xC2"
```

Similarly enum completions and labels for this include raw 0xC2:
```lua
---@enum (key) Broken
local Broken = { ["\xC2"] = 1 }
```

- Follow-up to @Wilfred's https://github.com/LuaLS/lua-language-server/pull/3446
- See: https://github.com/zed-extensions/lua/issues/61